### PR TITLE
Fix iA3 training for SDXL, use first text encoder

### DIFF
--- a/lycoris/kohya/__init__.py
+++ b/lycoris/kohya/__init__.py
@@ -868,7 +868,7 @@ class IA3Network(torch.nn.Module):
 
         self.text_encoder_loras = create_modules(
             IA3Network.LORA_PREFIX_TEXT_ENCODER,
-            text_encoder, 
+            text_encoder[0] if isinstance(text_encoder, list) else text_encoder,
             IA3Network.TEXT_ENCODER_TARGET_REPLACE_MODULE,
             IA3Network.TEXT_ENCODER_TARGET_REPLACE_NAME,
             IA3Network.TRAIN_INPUT


### PR DESCRIPTION
This PR allows training iA3 network when text_encoder is a list, such as in the case of SDXL's two text encoders.

It would be better to have a more robust system for handling cases where there is more than one text encoder / u-net, but as far as I know SDXL is the only exception.