### PR TITLE
fix `AttributeError` when loading DyLoRA in kohya/__init__.py

### DIFF
--- a/lycoris/kohya/__init__.py
+++ b/lycoris/kohya/__init__.py
@@ -92,7 +92,7 @@ def create_network(multiplier, network_dim, network_alpha, vae, text_encoder, un
     
     if algo=='dylora':
         #dylora didn't support scale weight norm yet
-        delattr(network, 'apply_max_norm_regularization')
+        delattr(type(network), 'apply_max_norm_regularization')
     
     return network
 


### PR DESCRIPTION
Trying to delete a method on a instance using `delattr` will cause an `AttributeError`.
We have to delete it from class definition.