### PR TITLE
Proposal to add rank_dropout scale

### DIFF
--- a/lycoris/modules/full.py
+++ b/lycoris/modules/full.py
@@ -18,7 +18,7 @@ class FullModule(nn.Module):
         multiplier=1.0, 
         lora_dim=4, alpha=1, 
         dropout=0., rank_dropout=0., module_dropout=0.,
-        use_tucker=False, use_scalar=False,
+        use_tucker=False, use_scalar=False, rank_dropout_scale=False
         **kwargs,
     ):
         """ if alpha == 0 or None, alpha is rank (no scaling). """
@@ -47,6 +47,7 @@ class FullModule(nn.Module):
             self.diff_b = None
         
         self.rank_dropout = rank_dropout
+        self.rank_dropout_scale = rank_dropout_scale
         self.module_dropout = module_dropout
         
         self.multiplier = multiplier
@@ -59,7 +60,8 @@ class FullModule(nn.Module):
     def make_weight(self, scale = 1, device=None):
         if self.rank_dropout and self.training:
             drop = (torch.rand(self.dim, device=device) < self.rank_dropout).to(self.diff.dtype)
-            drop /= drop.mean()
+            if self.rank_dropout_scale:
+                drop /= drop.mean()
         else:
             drop = 1
         org_weight = self.org_module[0].weight.to(device, dtype=self.diff.dtype)

--- a/lycoris/modules/full.py
+++ b/lycoris/modules/full.py
@@ -57,11 +57,11 @@ class FullModule(nn.Module):
         self.org_module[0].forward = self.forward
 
     def make_weight(self, scale = 1, device=None):
-        drop = (
-            torch.rand(self.dim, device=device) < self.rank_dropout 
-            if self.rank_dropout and self.training 
-            else 1
-        )
+        if self.rank_dropout and self.training:
+            drop = (torch.rand(self.dim, device=device) < self.rank_dropout).to(self.diff.dtype)
+            drop /= drop.mean()
+        else:
+            drop = 1
         org_weight = self.org_module[0].weight.to(device, dtype=self.diff.dtype)
         weight = self.diff.to(device) * drop * scale
         weight = weight + org_weight

--- a/lycoris/modules/glokr.py
+++ b/lycoris/modules/glokr.py
@@ -78,6 +78,7 @@ class LokrModule(nn.Module):
         use_tucker=False,
         decompose_both = False,
         factor:int=-1, # factorization factor
+        rank_dropout_scale=False,
         **kwargs,
     ):
         """ if alpha == 0 or None, alpha is rank (no scaling). """
@@ -160,6 +161,7 @@ class LokrModule(nn.Module):
         if dropout:
             print("[WARN]LoHa/LoKr haven't implemented normal dropout yet.")
         self.rank_dropout = rank_dropout
+        self.rank_dropout_scale = rank_dropout_scale
         self.module_dropout = module_dropout
         
         if isinstance(alpha, torch.Tensor):
@@ -214,7 +216,8 @@ class LokrModule(nn.Module):
         if self.training and self.rank_dropout:
             drop = (torch.rand(weight.size(0)) < self.rank_dropout).to(weight.dtype)
             drop = drop.view(-1, *[1] * len(weight.shape[1:])).to(weight.device)
-            drop /= drop.mean()
+            if self.rank_dropout_scale:
+                drop /= drop.mean()
             weight *= drop
         return weight
 

--- a/lycoris/modules/glokr.py
+++ b/lycoris/modules/glokr.py
@@ -212,8 +212,10 @@ class LokrModule(nn.Module):
         if orig_weight is not None:
             weight = weight.reshape(orig_weight.shape)
         if self.training and self.rank_dropout:
-            drop = torch.rand(weight.size(0)) < self.rank_dropout
-            weight *= drop.view(-1, [1]*len(weight.shape[1:])).to(weight.device)
+            drop = (torch.rand(weight.size(0)) < self.rank_dropout).to(weight.dtype)
+            drop = drop.view(-1, *[1] * len(weight.shape[1:])).to(weight.device)
+            drop /= drop.mean()
+            weight *= drop
         return weight
 
     @torch.no_grad()

--- a/lycoris/modules/glora.py
+++ b/lycoris/modules/glora.py
@@ -89,8 +89,10 @@ class GLoRAModule(nn.Module):
         bx_mid = self.b1(x) * scale
         
         if self.rank_dropout and self.training:
-            drop_a = torch.rand(self.lora_dim, device=ax_mid.device) < self.rank_dropout
-            drop_b = torch.rand(self.lora_dim, device=bx_mid.device) < self.rank_dropout
+            drop_a = (torch.rand(self.lora_dim, device=ax_mid.device) < self.rank_dropout).to(ax_mid.dtype)
+            drop_a /= drop_a.mean()
+            drop_b = (torch.rand(self.lora_dim, device=bx_mid.device) < self.rank_dropout).to(bx_mid.dtype)
+            drop_b /= drop_b.mean()
             if (dims:=len(x.shape)) == 4:
                 drop_a = drop_a.view(1, -1, 1, 1)
                 drop_b = drop_b.view(1, -1, 1, 1)

--- a/lycoris/modules/glora.py
+++ b/lycoris/modules/glora.py
@@ -17,6 +17,7 @@ class GLoRAModule(nn.Module):
         multiplier=1.0, 
         lora_dim=4, alpha=1, 
         dropout=0., rank_dropout=0., module_dropout=0.,
+        rank_dropout_scale=False,
         *args,
         **kwargs,
     ):
@@ -50,6 +51,7 @@ class GLoRAModule(nn.Module):
         else:
             self.dropout = nn.Identity()
         self.rank_dropout = rank_dropout
+        self.rank_dropout_scale = rank_dropout_scale
         self.module_dropout = module_dropout
         
         if type(alpha) == torch.Tensor:
@@ -90,9 +92,11 @@ class GLoRAModule(nn.Module):
         
         if self.rank_dropout and self.training:
             drop_a = (torch.rand(self.lora_dim, device=ax_mid.device) < self.rank_dropout).to(ax_mid.dtype)
-            drop_a /= drop_a.mean()
+            if self.rank_dropout_scale:
+                drop_a /= drop_a.mean()
             drop_b = (torch.rand(self.lora_dim, device=bx_mid.device) < self.rank_dropout).to(bx_mid.dtype)
-            drop_b /= drop_b.mean()
+            if self.rank_dropout_scale:
+                drop_b /= drop_b.mean()
             if (dims:=len(x.shape)) == 4:
                 drop_a = drop_a.view(1, -1, 1, 1)
                 drop_b = drop_b.view(1, -1, 1, 1)

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -204,7 +204,8 @@ class LoConModule(nn.Module):
             mid = self.down_op(x, weight)
         
         if self.rank_dropout and self.training:
-            drop = torch.rand(self.lora_dim, device=mid.device) < self.rank_dropout
+            drop = (torch.rand(self.lora_dim, device=mid.device) < self.rank_dropout).to(mid.dtype)
+            drop /= drop.mean()
             if (dims:=len(x.shape)) == 4:
                 drop = drop.view(1, -1, 1, 1)
             else:
@@ -250,7 +251,8 @@ class LoConModule(nn.Module):
             mid = self.lora_down(x)
         
         if self.rank_dropout and self.training:
-            drop = torch.rand(self.lora_dim, device=mid.device) < self.rank_dropout
+            drop = (torch.rand(self.lora_dim, device=mid.device) < self.rank_dropout).to(mid.dtype)
+            drop /= drop.mean()
             if (dims:=len(x.shape)) == 4:
                 drop = drop.view(1, -1, 1, 1)
             else:

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -95,6 +95,7 @@ class LohaModule(nn.Module):
         dropout=0., rank_dropout=0., module_dropout=0.,
         use_tucker=False,
         use_scalar=False,
+        rank_dropout_scale=False,
         **kwargs,
     ):
         """ if alpha == 0 or None, alpha is rank (no scaling). """
@@ -146,6 +147,7 @@ class LohaModule(nn.Module):
         if dropout:
             print("[WARN]LoHa/LoKr haven't implemented normal dropout yet.")
         self.rank_dropout = rank_dropout
+        self.rank_dropout_scale = rank_dropout_scale
         self.module_dropout = module_dropout
         
         if type(alpha) == torch.Tensor:
@@ -199,7 +201,8 @@ class LohaModule(nn.Module):
         if self.training and self.rank_dropout:
             drop = (torch.rand(weight.size(0)) < self.rank_dropout).to(weight.dtype)
             drop = drop.view(-1, *[1] * len(weight.shape[1:])).to(weight.device)
-            drop /= drop.mean()
+            if self.rank_dropout_scale:
+                drop /= drop.mean()
             weight *= drop
         return weight
     

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -197,8 +197,10 @@ class LohaModule(nn.Module):
         if orig_weight is not None:
             weight = weight.reshape(orig_weight.shape)
         if self.training and self.rank_dropout:
-            drop = torch.rand(weight.size(0)) < self.rank_dropout
-            weight *= drop.view(-1, [1]*len(weight.shape[1:])).to(weight.device)
+            drop = (torch.rand(weight.size(0)) < self.rank_dropout).to(weight.dtype)
+            drop = drop.view(-1, *[1] * len(weight.shape[1:])).to(weight.device)
+            drop /= drop.mean()
+            weight *= drop
         return weight
     
     def state_dict(self, *args, destination=None, prefix='', keep_vars=False):

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -231,8 +231,9 @@ class LokrModule(nn.Module):
         if orig_weight is not None:
             weight = weight.reshape(orig_weight.shape)
         if self.training and self.rank_dropout:
-            drop = torch.rand(weight.size(0)) < self.rank_dropout
-            weight *= drop.view(-1, [1]*len(weight.shape[1:])).to(weight.device)
+            drop = (torch.rand(weight.size(0)) < self.rank_dropout).to(weight.dtype)
+            drop = drop.view(-1, *[1] * len(weight.shape[1:])).to(weight.device)
+            drop /= drop.mean()
         return weight
     
     def state_dict(self, *args, destination=None, prefix='', keep_vars=False):

--- a/lycoris/modules/norms.py
+++ b/lycoris/modules/norms.py
@@ -16,6 +16,7 @@ class NormModule(nn.Module):
         self, 
         lora_name, org_module: nn.Module, 
         multiplier=1.0, rank_dropout=0., module_dropout=0.,
+        rank_dropout_scale=False,
         **kwargs,
     ):
         """ if alpha == 0 or None, alpha is rank (no scaling). """
@@ -37,6 +38,7 @@ class NormModule(nn.Module):
         self.b_norm = nn.Parameter(torch.zeros(self.dim))
         
         self.rank_dropout = rank_dropout
+        self.rank_dropout_scale = rank_dropout_scale
         self.module_dropout = module_dropout
         
         self.multiplier = multiplier
@@ -51,7 +53,8 @@ class NormModule(nn.Module):
         org_bias = self.org_module[0].bias.to(device, dtype=self.b_norm.dtype)
         if self.rank_dropout and self.training:
             drop = (torch.rand(self.dim, device=device) < self.rank_dropout).to(self.w_norm.device)
-            drop /= drop.mean()
+            if self.rank_dropout_scale:
+                drop /= drop.mean()
         else:
             drop = 1
         drop = (

--- a/lycoris/modules/norms.py
+++ b/lycoris/modules/norms.py
@@ -49,6 +49,11 @@ class NormModule(nn.Module):
     def make_weight(self, scale = 1, device=None):
         org_weight = self.org_module[0].weight.to(device, dtype=self.w_norm.dtype)
         org_bias = self.org_module[0].bias.to(device, dtype=self.b_norm.dtype)
+        if self.rank_dropout and self.training:
+            drop = (torch.rand(self.dim, device=device) < self.rank_dropout).to(self.w_norm.device)
+            drop /= drop.mean()
+        else:
+            drop = 1
         drop = (
             torch.rand(self.dim, device=device) < self.rank_dropout 
             if self.rank_dropout and self.training 


### PR DESCRIPTION
Hi @KohakuBlueleaf! Thank you very much for your awesome library!

I was reading through your adapters code and was wondering - why there is no scaling when doing `rank_dropout`?

According to torch docs [nn.Dropout](https://pytorch.org/docs/stable/generated/torch.nn.Dropout.html) performs scaling of output values using the provided dropout probability to retain the overall normalization the same.

<img width="875" alt="Screenshot 2023-09-28 at 13 58 39" src="https://github.com/KohakuBlueleaf/LyCORIS/assets/1431206/5154d3b2-ab79-4d6b-b42d-301cafb2912e">

I am not sure whether your implementation does have this scale intentionally or not (probably the further group normalization neutralizes the lack of this scale), but I've made several experiments, and adding this scaling may help training a bit faster if dropout is enabled.