### PR TITLE
LoHa does not take into account hada_t2 parameter

### DIFF
--- a/lycoris/hcp/loha.py
+++ b/lycoris/hcp/loha.py
@@ -46,7 +46,7 @@ class LohaBlock(LycorisPluginBlock):
         if self.tucker:
             weight = make_weight_cp(
                 self.hada_t1, self.hada_w1_a, self.hada_w1_b,
-                self.hada_t1, self.hada_w2_a, self.hada_w2_b,
+                self.hada_t2, self.hada_w2_a, self.hada_w2_b,
                 scale = torch.tensor(self.scale),
             )
         else:

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -187,7 +187,7 @@ class LohaModule(nn.Module):
         if self.tucker:
             weight = make_weight_cp(
                 self.hada_t1, self.hada_w1_a, self.hada_w1_b,
-                self.hada_t1, self.hada_w2_a, self.hada_w2_b,
+                self.hada_t2, self.hada_w2_a, self.hada_w2_b,
                 scale = torch.tensor(self.scale),
             )
         else:


### PR DESCRIPTION
Hi!

I've found a strange behaviour, that LoHa doesn't take `hada_t2` parameter into account during training/inference.

I assume that it could be a mistake and almost sure that it should be fixed and it will probably make output results even better.

Could you please confirm that?  If so, we will certainly need to provide some sort of backward compatibility in the following commits.