### PR TITLE
Fix: use .items() for custom_sd dict

### DIFF
--- a/lycoris/modules/base.py
+++ b/lycoris/modules/base.py
@@ -28,7 +28,7 @@ class ModuleCustomSD(nn.Module):
             destination._metadata[prefix[:-1]] = local_metadata
         
         if (custom_sd := self.custom_state_dict()) is not None:
-            for k, v in custom_sd:
+            for k, v in custom_sd.items():
                 destination[f'{prefix}{k}'] = v
             return destination
         else:


### PR DESCRIPTION
Fix for saving, custom_sd is a dict
```
  File "F:/stablediffusion/kohya_ss/sdxl_train_network.py", line 185, in <module>
    trainer.train(args)
  File "F:\stablediffusion\kohya_ss\train_network.py", line 854, in train
    save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch)
  File "F:\stablediffusion\kohya_ss\train_network.py", line 736, in save_model
    unwrapped_nw.save_weights(ckpt_file, save_dtype, metadata_to_save)
  File "f:\stablediffusion\kohya_ss\venv\lib\site-packages\lycoris\kohya\__init__.py", line 568, in save_weights
    state_dict = self.state_dict()
  File "f:\stablediffusion\kohya_ss\venv\lib\site-packages\torch\nn\modules\module.py", line 1818, in state_dict
    module.state_dict(destination=destination, prefix=prefix + name + '.', keep_vars=keep_vars)
  File "f:\stablediffusion\kohya_ss\venv\lib\site-packages\lycoris\modules\base.py", line 31, in state_dict
    for k, v in custom_sd:
ValueError: too many values to unpack (expected 2)
```