### PR TITLE
Fix: save name as oft_blocks for coft

### DIFF
--- a/lycoris/modules/diag_oft.py
+++ b/lycoris/modules/diag_oft.py
@@ -69,11 +69,12 @@ class DiagOFTModule(ModuleCustomSD):
     def apply_to(self, **kwargs):
         self.org_forward = self.org_module[0].forward
         self.org_module[0].forward = self.forward
-    
+
     def custom_state_dict(self):
+        oft_name = 'oft_blocks' if self.constrain > 0 else 'oft_diag'
         return {
-            'oft_diag': self.get_r()
-        }
+            oft_name: self.get_r()
+        } 
     
     def get_r(self):
         if self.constrain > 0:


### PR DESCRIPTION
This PR fixes the name in the state dict always being "oft_dict" when it should be "oft_blocks" for COFT.