### PR TITLE
Fix: use float for constrain

### DIFF
--- a/lycoris/kohya/__init__.py
+++ b/lycoris/kohya/__init__.py
@@ -63,7 +63,7 @@ def create_network(multiplier, network_dim, network_alpha, vae, text_encoder, un
     use_scalar = str_bool(kwargs.get('use_scalar', False))
     block_size = int(kwargs.get('block_size', 4) or 4)
     train_norm = str_bool(kwargs.get('train_norm', False))
-    constrain = int(kwargs.get('constrain', 0) or 0)
+    constrain = float(kwargs.get('constrain', 0) or 0)
     rescaled = str_bool(kwargs.get('rescaled', False))
     
     if algo == 'glora' and conv_dim>0:

--- a/lycoris/modules/diag_oft.py
+++ b/lycoris/modules/diag_oft.py
@@ -47,7 +47,7 @@ class DiagOFTModule(ModuleCustomSD):
         self.block_size, self.block_num = factorization(out_dim, lora_dim)
         # block_num > block_size
         self.rescaled = rescaled
-        self.constrain = constrain
+        self.constrain = constrain * out_dim
         self.oft_blocks = nn.Parameter(torch.zeros(self.block_num, self.block_size, self.block_size))
         if rescaled:
             self.rescale = nn.Parameter(torch.ones(self.block_num, self.block_size, 1))


### PR DESCRIPTION
This PR fixes constrain being rounded to an int (my fault), which would be a problem if you want a very small constraint as discussed in the paper.

This PR also changes constrain to be ε * _d_, where _d == out_dim_ of the module (pg. 6, Figure 5). In cases where constrain is not specified in args, constrain defaults to 0 (int) so it should still be OFT.