### PR TITLE
kohya-ss/sd-scripts example didn't seem to work. Updated README and added a Dataset config to streamline running train_network.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can use this package's kohya module to run kohya's training script to train 
   ```bash
   accelerate launch train_network.py \
     --config_file example_configs/training_configs/kohya/loha_config.toml \
-    --dataset_config example_configs/training_confics/kohya/dataset_config.toml
+    --dataset_config example_configs/training_configs/kohya/dataset_config.toml
   ```
 
   For your convenience, some example `toml` files for kohya LyCORIS training are provided in [example/training_configs/kohya](example_configs/training_configs/kohya).

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ You can use this package's kohya module to run kohya's training script to train 
 
   ```bash
   accelerate launch train_network.py \
-    --config_file example_configs/training_configs/kohya/loha_config.toml
+    --config_file example_configs/training_configs/kohya/loha_config.toml \
+    --dataset_config example_configs/training_confics/kohya/dataset_config.toml
   ```
 
   For your convenience, some example `toml` files for kohya LyCORIS training are provided in [example/training_configs/kohya](example_configs/training_configs/kohya).

--- a/example_configs/training_configs/kohya/dataset_config.toml
+++ b/example_configs/training_configs/kohya/dataset_config.toml
@@ -1,0 +1,11 @@
+[[datasets]]
+keep_tokens = 1
+
+        [[datasets.subsets]]
+        image_dir = ''
+        class_tokens = ''
+        num_repeats = 1
+
+[general]
+resolution = 512
+


### PR DESCRIPTION
When using the provided examples with sd-scripts, the 'train_data_dir' was always ignored and images weren't found. Added dataset config to rectify the issue and updated the command in the README