### PR TITLE
Updated LoRA trigger description

### DIFF
--- a/docs/Algo-List.md
+++ b/docs/Algo-List.md
@@ -6,7 +6,7 @@ All the methods below except for GLoKr are supported in a1111/sd-webui.
 However, newer methods may only be available in the latest release / the dev branch.
 
 ### Conventional LoRA
-* Trigged by `algo=lora`
+* Trigged by `algo=lora` or `algo=locon` (Just alias)
 * Includes Conv layer implementation from LoCon.
 * Recommended settings
   * dim <= 64


### PR DESCRIPTION
According to the code, two triggers call the same module.

https://github.com/KohakuBlueleaf/LyCORIS/blob/c7abd083ad9bc3e18cd3e64b6433eff8525922f6/lycoris/kohya/__init__.py#L35-L36

This pull request makes it clear.

## Context

After I read the following instruction in README, I read the algorithm list, but I couldn't find `locon`

https://github.com/KohakuBlueleaf/LyCORIS/blob/c7abd083ad9bc3e18cd3e64b6433eff8525922f6/README.md?plain=1#L93-L97