### PR TITLE
fix: save dora_scale in locon.py

### DIFF
--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -185,6 +185,8 @@ class LoConModule(ModuleCustomSD):
 
     def custom_state_dict(self):
         destination = {}
+        if self.wd:
+            destination["dora_scale"] = self.dora_scale
         destination["alpha"] = self.alpha
         destination["lora_up.weight"] = self.lora_up.weight * self.scalar
         destination["lora_down.weight"] = self.lora_down.weight


### PR DESCRIPTION
there is no save dora_scale code in the locon.py