### PR TITLE
Fix division by zero weight_norm causes NaN loss in DoRA

### DIFF
--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -203,7 +203,7 @@ class LoConModule(ModuleCustomSD):
             .norm(dim=1, keepdim=True)
             .reshape(weight.shape[1], *[1] * self.dora_norm_dims)
             .transpose(0, 1)
-        )
+        ) + torch.finfo(weight.dtype).eps
 
         return weight * (self.dora_scale.to(weight.device) / weight_norm)
 

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -274,7 +274,7 @@ class LohaModule(ModuleCustomSD):
             .norm(dim=1, keepdim=True)
             .reshape(weight.shape[1], *[1] * self.dora_norm_dims)
             .transpose(0, 1)
-        )
+        ) + torch.finfo(weight.dtype).eps
 
         return weight * (self.dora_scale.to(weight.device) / weight_norm)
 

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -344,7 +344,7 @@ class LokrModule(ModuleCustomSD):
             .norm(dim=1, keepdim=True)
             .reshape(weight.shape[1], *[1] * self.dora_norm_dims)
             .transpose(0, 1)
-        )
+        ) + torch.finfo(weight.dtype).eps
 
         return weight * (self.dora_scale.to(weight.device) / weight_norm)
 


### PR DESCRIPTION
In apply_weight_decompose, weight_norm can equal 0 which causes NaN weight during training.

We can prevent the division by zero by adding a very small value to weight_norm.