### PR TITLE
Addition of Rank-Stabilized LoRA parameter

### DIFF
--- a/lycoris/kohya/__init__.py
+++ b/lycoris/kohya/__init__.py
@@ -80,10 +80,6 @@ def create_network(
 
     if weight_decompose:
         logger.info("Weight decomposition is enabled")
-        logger.warning(
-            "Weight Decomposition will need lower Learning Rate. "
-            "If you met high loss or NaN problem, try to use lower LR."
-        )
 
     if full_matrix:
         logger.info("Full matrix mode for LoKr is enabled")

--- a/lycoris/kohya/__init__.py
+++ b/lycoris/kohya/__init__.py
@@ -74,6 +74,7 @@ def create_network(
     weight_decompose = str_bool(kwargs.get("dora_wd", False))
     full_matrix = str_bool(kwargs.get("full_matrix", False))
     bypass_mode = str_bool(kwargs.get("bypass_mode", False))
+    rs_lora = str_bool(kwargs.get("rs_lora", False))
 
     if bypass_mode:
         logger.info("Bypass mode is enabled")
@@ -141,6 +142,7 @@ def create_network(
             weight_decompose=weight_decompose,
             full_matrix=full_matrix,
             bypass_mode=bypass_mode,
+            rs_lora=rs_lora
         )
 
     if algo == "dylora":

--- a/lycoris/modules/glokr.py
+++ b/lycoris/modules/glokr.py
@@ -1,4 +1,5 @@
 import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/lycoris/modules/glokr.py
+++ b/lycoris/modules/glokr.py
@@ -1,4 +1,5 @@
 import torch
+import math
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/lycoris/modules/glokr.py
+++ b/lycoris/modules/glokr.py
@@ -83,6 +83,7 @@ class LokrModule(ModuleCustomSD):
         decompose_both=False,
         factor: int = -1,  # factorization factor
         rank_dropout_scale=False,
+        rs_lora=False,
         **kwargs,
     ):
         """if alpha == 0 or None, alpha is rank (no scaling)."""
@@ -93,6 +94,7 @@ class LokrModule(ModuleCustomSD):
         self.tucker = False
         self.use_w1 = False
         self.use_w2 = False
+        self.rs_lora = rs_lora
 
         self.shape = org_module.weight.shape
         if org_module.__class__.__name__ == "Conv2d":
@@ -191,7 +193,13 @@ class LokrModule(ModuleCustomSD):
         if self.use_w2 and self.use_w1:
             # use scale = 1
             alpha = lora_dim
-        self.scale = alpha / self.lora_dim
+        
+        r_factor = lora_dim
+        if self.rs_lora:
+            r_factor = math.sqrt(r_factor)
+
+        self.scale = alpha / r_factor
+
         self.register_buffer("alpha", torch.tensor(alpha))  # 定数として扱える
 
         if self.use_w2:

--- a/lycoris/modules/glokr.py
+++ b/lycoris/modules/glokr.py
@@ -1,5 +1,5 @@
-import torch
 import math
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/lycoris/modules/glora.py
+++ b/lycoris/modules/glora.py
@@ -1,4 +1,5 @@
 import math
+
 import torch
 import torch.nn as nn
 

--- a/lycoris/modules/glora.py
+++ b/lycoris/modules/glora.py
@@ -1,5 +1,4 @@
 import math
-
 import torch
 import torch.nn as nn
 

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -1,4 +1,5 @@
 import math
+
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import math
 
 from .base import ModuleCustomSD
 from ..utils.bnb import LinearNF4, QuantLinears, log_bypass
@@ -102,6 +103,7 @@ class LohaModule(ModuleCustomSD):
         rank_dropout_scale=False,
         weight_decompose=False,
         bypass_mode=False,
+        rs_lora=False,
         **kwargs,
     ):
         """if alpha == 0 or None, alpha is rank (no scaling)."""
@@ -109,6 +111,7 @@ class LohaModule(ModuleCustomSD):
         self.lora_name = lora_name
         self.lora_dim = lora_dim
         self.tucker = False
+        self.rs_lora = rs_lora
 
         self.shape = org_module.weight.shape
         if org_module.__class__.__name__ == "Conv2d":

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -196,7 +196,13 @@ class LohaModule(ModuleCustomSD):
         if type(alpha) == torch.Tensor:
             alpha = alpha.detach().float().numpy()  # without casting, bf16 causes error
         alpha = lora_dim if alpha is None or alpha == 0 else alpha
-        self.scale = alpha / self.lora_dim
+        
+        r_factor = lora_dim
+        if self.rs_lora:
+            r_factor = math.sqrt(r_factor)
+
+        self.scale = alpha / r_factor
+
         self.register_buffer("alpha", torch.tensor(alpha))  # 定数として扱える
 
         if use_scalar:

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -1,7 +1,7 @@
+import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import math
 
 from .base import ModuleCustomSD
 from ..utils.bnb import LinearNF4, QuantLinears, log_bypass

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -105,6 +105,7 @@ class LokrModule(ModuleCustomSD):
         weight_decompose=False,
         full_matrix=False,
         bypass_mode=False,
+        rs_lora=False,
         **kwargs,
     ):
         """if alpha == 0 or None, alpha is rank (no scaling)."""
@@ -116,6 +117,7 @@ class LokrModule(ModuleCustomSD):
         self.use_w1 = False
         self.use_w2 = False
         self.full_matrix = full_matrix
+        self.rs_lora = rs_lora
 
         self.shape = org_module.weight.shape
         if org_module.__class__.__name__ == "Conv2d":
@@ -242,7 +244,13 @@ class LokrModule(ModuleCustomSD):
         if self.use_w2 and self.use_w1:
             # use scale = 1
             alpha = lora_dim
-        self.scale = alpha / self.lora_dim
+
+        r_factor = lora_dim
+        if self.rs_lora:
+            r_factor = math.sqrt(r_factor)
+
+        self.scale = alpha / r_factor
+
         self.register_buffer("alpha", torch.tensor(alpha))  # 定数として扱える
 
         if use_scalar:

--- a/lycoris/wrapper.py
+++ b/lycoris/wrapper.py
@@ -75,10 +75,6 @@ def create_lycoris(module, multiplier, linear_dim, linear_alpha, **kwargs):
 
     if weight_decompose:
         logger.info("Weight decomposition is enabled")
-        logger.warning(
-            "Weight Decomposition will need lower Learning Rate. "
-            "If you met high loss or NaN problem, try to use lower LR."
-        )
 
     if full_matrix:
         logger.info("Full matrix mode for LoKr is enabled")

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     name="lycoris_lora",
     packages=find_packages(),
-    version="2.2.0.post2",
+    version="2.2.0.post3",
     url="https://github.com/KohakuBlueleaf/LyCORIS",
     description="Lora beYond Conventional methods, Other Rank adaptation Implementations for Stable diffusion",
     author="Shih-Ying Yeh(KohakuBlueLeaf), Yu-Guan Hsieh, Zhidong Gao",


### PR DESCRIPTION
Concept from: https://huggingface.co/blog/damjan-k/rslora

Adds rs-lora parameter to create_network.

Adds rs-lora scaling to the following networks:
glokr
glora
lilora
locon
loha
lokr

For all networks, the change is the same:
```python
self.scale = alpha / lora_dim
```
Becomes
```python
r_factor = lora_dim
if self.rs_lora:
    r_factor = math.sqrt(r_factor)

self.scale = alpha / r_factor
```

Training via dora showed that their were still potentially issues with this scaling factor, the addition of the sqrt term does experimentally seem to allow larger rank networks. The implementation is currently a bit strange, I wanted to do things in the least obtrusive way possible for clarity. Let me know if you'd like the code to be reorganized or refactored to decouple the lora_dim and r_factors.

Testing was carried out with locon and loha, I am currently performing ablations with the other flavors.