### PR TITLE
Fix an error in LoHa functional implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please check [List of Implemented Algorithms](docs/Algo-List.md) and [Guidelines
 
 A simple comparison of some of these methods are provided below (to be taken with a grain of salt)
 
-|                       | Full | LoRA | LoHa | LoKr low factor | LoKr high factor$^+$ |
+|                       | Full | LoRA | LoHa | LoKr low factor | LoKr high factor $^+$ |
 | --------------------- | ---- | ---- | ---- | --------------- | ---------------------- |
 | Fidelity              | ★   | ●   | ▲   | ◉              | ▲                     |
 | Flexibility $^*$     | ★   | ●   | ◉   | ▲              | ● $^†$              |

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ A simple comparison of some of these methods are provided below (to be taken wit
 ★ > ◉ > ● > ▲
 [> means better and smaller size is better]
 
-$^+$ Usually we take `factor <= 0.5 * sqrt(dim)` as low factor and `factor >= sqrt(dim` as high factor. For example, factor<=8 for SD1.x/SD2.x/SDXL can be seen as low factor, and, factor>=16 can be seen as high factor. `<br>`
-$^*$ Flexibility means anything related to generating images not similar to those in the training set, and combination of multiple concepts, whether they are trained together or not `<br>`
-$^†$ It may become more difficult to switch base model or combine multiple concepts in this situation `<br>`
+$^+$ Usually we take `factor <= 0.5 * sqrt(dim)` as low factor and `factor >= sqrt(dim` as high factor. For example, factor<=8 for SD1.x/SD2.x/SDXL can be seen as low factor, and, factor>=16 can be seen as high factor. <br>
+$^*$ Flexibility means anything related to generating images not similar to those in the training set, and combination of multiple concepts, whether they are trained together or not <br>
+$^†$ It may become more difficult to switch base model or combine multiple concepts in this situation <br>
 
 **The actual performance may vary depending on the datasets, tasks, and hyperparameters used. It is recommended to experiment with different settings to achieve optimal results.**
 

--- a/lycoris/functional/loha.py
+++ b/lycoris/functional/loha.py
@@ -141,7 +141,7 @@ def diff_weight(w1d, w1u, w2d, w2u, t1=None, t2=None, gamma=1.0):
         w1d = w1d.reshape(w1d.size(0), -1)
         w1u = w1u.reshape(-1, w1u.size(1))
         w2d = w2d.reshape(w2d.size(0), -1)
-        w2u = w1u.reshape(-1, w2u.size(1))
+        w2u = w2u.reshape(-1, w2u.size(1))
         result = make_weight(w1d, w1u, w2d, w2u, gamma)
 
     result = result.reshape(O, I, *k)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch
 toml
 einops
+setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
This typo meant that any LoHa created with this implementation had 25% fewer trainable parameters than it should have, as well as likely some additional second-order effects from these two values being forced to be equivalent.