### PR TITLE
Compatibility fixes and features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 data/
 
 # test
+models/
 test_model/
 huggingface/
 logs/

--- a/lycoris/wrapper.py
+++ b/lycoris/wrapper.py
@@ -1,5 +1,6 @@
 # General LyCORIS wrapper based on kohya-ss/sd-scripts' style
 import os
+import fnmatch
 import re
 import logging
 
@@ -23,6 +24,22 @@ from .config import PRESET
 from .utils.preset import read_preset
 from .utils import str_bool
 from .logging import logger
+
+
+VALID_PRESET_KEYS = [
+    "enable_conv",
+    "target_module",
+    "target_name",
+    "module_algo_map",
+    "name_algo_map",
+    "lora_prefix",
+    "use_fnmatch",
+    "unet_target_module",
+    "unet_target_name",
+    "text_encoder_target_module",
+    "text_encoder_target_name",
+    "exclude_name",
+]
 
 
 network_module_dict = {
@@ -189,9 +206,16 @@ class LycorisNetwork(torch.nn.Module):
     LORA_PREFIX = "lycoris"
     MODULE_ALGO_MAP = {}
     NAME_ALGO_MAP = {}
+    USE_FNMATCH = False
+    TARGET_EXCLUDE_NAME = []
 
     @classmethod
     def apply_preset(cls, preset):
+        for preset_key in preset.keys():
+            if preset_key not in VALID_PRESET_KEYS:
+                raise KeyError(
+                    f'Unknown preset key "{preset_key}". Valid keys: {VALID_PRESET_KEYS}')
+
         if "enable_conv" in preset:
             cls.ENABLE_CONV = preset["enable_conv"]
         if "target_module" in preset:
@@ -202,6 +226,12 @@ class LycorisNetwork(torch.nn.Module):
             cls.MODULE_ALGO_MAP = preset["module_algo_map"]
         if "name_algo_map" in preset:
             cls.NAME_ALGO_MAP = preset["name_algo_map"]
+        if "lora_prefix" in preset:
+            cls.LORA_PREFIX = preset["lora_prefix"]
+        if "use_fnmatch" in preset:
+            cls.USE_FNMATCH = preset["use_fnmatch"]
+        if "exclude_name" in preset:
+            cls.TARGET_EXCLUDE_NAME = preset["exclude_name"]
         return cls
 
     def __init__(
@@ -324,30 +354,42 @@ class LycorisNetwork(torch.nn.Module):
             prefix: str,
             root_module: torch.nn.Module,
             algo,
+            current_lora_map: dict[str, Any],
             configs={},
         ):
-            loras = {}
+            assert current_lora_map is not None, "No mapping supplied"
+            loras = current_lora_map
             lora_names = []
             for name, module in root_module.named_modules():
                 module_name = module.__class__.__name__
                 if module_name in self.MODULE_ALGO_MAP and module is not root_module:
                     next_config = self.MODULE_ALGO_MAP[module_name]
                     next_algo = next_config.get("algo", algo)
-                    new_loras, new_lora_names = create_modules_(
+                    new_loras, new_lora_names, new_lora_map = create_modules_(
                         f"{prefix}_{name}" if name else prefix,
                         module,
                         next_algo,
-                        next_config,
+                        loras,
+                        configs=next_config,
                     )
+                    loras = { **loras, **new_lora_map }
                     for lora_name, lora in zip(new_lora_names, new_loras):
-                        if lora_name not in loras:
+                        if lora_name not in loras and lora_name not in current_lora_map:
                             loras[lora_name] = lora
                             lora_names.append(lora_name)
                     continue
+
                 if name:
                     lora_name = prefix + "." + name
                 else:
                     lora_name = prefix
+
+                if f"{self.LORA_PREFIX}_." in lora_name:
+                    lora_name = lora_name.replace(
+                        f"{self.LORA_PREFIX}_.",
+                        f"{self.LORA_PREFIX}.",
+                    )
+
                 lora_name = lora_name.replace(".", "_")
                 if lora_name in loras:
                     continue
@@ -356,7 +398,7 @@ class LycorisNetwork(torch.nn.Module):
                 if lora is not None:
                     loras[lora_name] = lora
                     lora_names.append(lora_name)
-            return [loras[lora_name] for lora_name in lora_names], lora_names
+            return [loras[lora_name] for lora_name in lora_names], lora_names, loras
 
         # create module instances
         def create_modules(
@@ -364,28 +406,40 @@ class LycorisNetwork(torch.nn.Module):
             root_module: torch.nn.Module,
             target_replace_modules,
             target_replace_names=[],
+            target_exclude_names=[],
         ) -> List:
             logger.info("Create LyCORIS Module")
             loras = []
+            lora_map = {}
             next_config = {}
             for name, module in root_module.named_modules():
+                if name in target_exclude_names or any(
+                    self.match_fn(t, name) for t in target_exclude_names
+                ):
+                    continue
+
                 module_name = module.__class__.__name__
                 if module_name in target_replace_modules and not any(
-                    re.match(t, name) for t in target_replace_names
+                    self.match_fn(t, name) for t in target_replace_names
                 ):
                     if module_name in self.MODULE_ALGO_MAP:
                         next_config = self.MODULE_ALGO_MAP[module_name]
                         algo = next_config.get("algo", network_module)
                     else:
                         algo = network_module
-                    loras.extend(
-                        create_modules_(f"{prefix}_{name}", module, algo, next_config)[
-                            0
-                        ]
+
+                    lora_lst, _, _lora_map = create_modules_(
+                        f"{prefix}_{name}",
+                        module,
+                        algo,
+                        lora_map,
+                        configs=next_config,
                     )
+                    lora_map = { **lora_map, **_lora_map }
+                    loras.extend(lora_lst)
                     next_config = {}
                 elif name in target_replace_names or any(
-                    re.match(t, name) for t in target_replace_names
+                    self.match_fn(t, name) for t in target_replace_names
                 ):
                     conf_from_name = self.find_conf_for_name(name)
                     if conf_from_name is not None:
@@ -398,9 +452,14 @@ class LycorisNetwork(torch.nn.Module):
                         algo = network_module
                     lora_name = prefix + "." + name
                     lora_name = lora_name.replace(".", "_")
+
+                    if lora_name in lora_map:
+                        continue
+
                     lora = create_single_module(lora_name, module, algo, **next_config)
                     next_config = {}
                     if lora is not None:
+                        lora_map[lora.lora_name] = lora
                         loras.append(lora)
             return loras
 
@@ -423,6 +482,7 @@ class LycorisNetwork(torch.nn.Module):
                     ]
                 )
             ),
+            target_exclude_names=LycorisNetwork.TARGET_EXCLUDE_NAME,
         )
         logger.info(f"create LyCORIS: {len(self.loras)} modules.")
 
@@ -433,13 +493,19 @@ class LycorisNetwork(torch.nn.Module):
             )
         logger.info(f"module type table: {algo_table}")
 
-        # assertion
+        # Assertion to ensure we have not accidentally wrapped some layers
+        # multiple times.
         names = set()
         for lora in self.loras:
             assert (
                 lora.lora_name not in names
             ), f"duplicated lora name: {lora.lora_name}"
             names.add(lora.lora_name)
+
+    def match_fn(self, pattern: str, name: str) -> bool:
+        if self.USE_FNMATCH:
+            return fnmatch.fnmatch(name, pattern)
+        return bool(re.match(pattern, name))
 
     def find_conf_for_name(
         self,
@@ -449,7 +515,7 @@ class LycorisNetwork(torch.nn.Module):
             return self.NAME_ALGO_MAP[name]
 
         for key, value in self.NAME_ALGO_MAP.items():
-            if re.match(key, name):
+            if self.match_fn(key, name):
                 return value
 
         return None
@@ -475,6 +541,9 @@ class LycorisNetwork(torch.nn.Module):
         return state
 
     def apply_to(self):
+        '''
+        Register to modules to the subclass so that torch sees them.
+        '''
         for lora in self.loras:
             lora.apply_to()
             self.add_module(lora.lora_name, lora)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ parameterized
 numpy
 safetensors
 tqdm
+diffusers==0.30.2

--- a/requirements-kohya.txt
+++ b/requirements-kohya.txt
@@ -1,8 +1,9 @@
 accelerate==0.25.0
 transformers==4.36.2
-diffusers[torch]==0.25.0
+diffusers[torch]==0.30.2
 ftfy==6.1.1
 # albumentations==1.3.0
+torchvision
 opencv-python==4.7.0.68
 einops==0.7.0
 pytorch-lightning==1.9.0

--- a/test/wrapper.py
+++ b/test/wrapper.py
@@ -7,7 +7,29 @@ from parameterized import parameterized
 import torch
 import torch.nn as nn
 
+from diffusers import FluxTransformer2DModel
+
 from lycoris import create_lycoris, create_lycoris_from_weights, LycorisNetwork
+
+
+def reset_globals():
+    LycorisNetwork.apply_preset({
+        'enable_conv': True,
+        'target_module': [
+            "Linear",
+            "Conv1d",
+            "Conv2d",
+            "Conv3d",
+            "GroupNorm",
+            "LayerNorm",
+        ],
+        'target_name': [],
+        'lora_prefix': "lycoris",
+        'module_algo_map': {},
+        'name_algo_map': {},
+        'use_fnmatch': False,
+        'exclude_name': []
+    })
 
 
 class TestNetwork(nn.Module):
@@ -149,151 +171,589 @@ class TestNetwork2(nn.Module):
 class LycorisWrapperTests(unittest.TestCase):
     @parameterized.expand(patch_forward_param_list)
     def test_lycoris_wrapper(self, algo, device_dtype, wd, tucker, scalar):
-        device, dtype = device_dtype
-        print(
-            f"{algo: <18}",
-            f"device={str(device): <5}",
-            f"dtype={str(dtype): <15}",
-            f"wd={str(wd): <6}",
-            f"tucker={str(tucker): <6}",
-            f"scalar={str(scalar): <6}",
-            sep="|| ",
-        )
-        test_net = TestNetwork(16).to(device, dtype)
-        test_lycoris: LycorisNetwork = create_lycoris(
-            test_net,
-            1,
-            algo=algo,
-            linear_dim=4,
-            linear_alpha=2.0,
-            conv_dim=4,
-            conv_alpha=2.0,
-            dropout=0.0,
-            rank_dropout=0.0,
-            weight_decompose=wd,
-            use_tucker=tucker,
-            use_scalar=scalar,
-            train_norm=True,
-        )
-        test_lycoris.apply_to()
-        test_lycoris.to(device, dtype)
+        try:
+            device, dtype = device_dtype
+            print(
+                f"{algo: <18}",
+                f"device={str(device): <5}",
+                f"dtype={str(dtype): <15}",
+                f"wd={str(wd): <6}",
+                f"tucker={str(tucker): <6}",
+                f"scalar={str(scalar): <6}",
+                sep="|| ",
+            )
+            test_net = TestNetwork(16).to(device, dtype)
+            test_lycoris: LycorisNetwork = create_lycoris(
+                test_net,
+                1,
+                algo=algo,
+                linear_dim=4,
+                linear_alpha=2.0,
+                conv_dim=4,
+                conv_alpha=2.0,
+                dropout=0.0,
+                rank_dropout=0.0,
+                weight_decompose=wd,
+                use_tucker=tucker,
+                use_scalar=scalar,
+                train_norm=True,
+            )
+            test_lycoris.apply_to()
+            test_lycoris.to(device, dtype)
 
-        test_input = torch.randn(1, 16, 8, 8, 8).to(device, dtype)
-        test_output = test_net(test_input)
-        test_lycoris.restore()
+            test_input = torch.randn(1, 16, 8, 8, 8).to(device, dtype)
+            test_output = test_net(test_input)
+            test_lycoris.restore()
 
-        state_dict = test_lycoris.state_dict()
-        test_lycoris_from_weights: LycorisNetwork
-        test_lycoris_from_weights, _ = create_lycoris_from_weights(
-            1, None, test_net, state_dict
-        )
-        test_lycoris_from_weights.apply_to()
-        test_lycoris_from_weights.to(device, dtype)
-        test_output_from_weights = test_net(test_input)
+            state_dict = test_lycoris.state_dict()
+            test_lycoris_from_weights: LycorisNetwork
+            test_lycoris_from_weights, _ = create_lycoris_from_weights(
+                1, None, test_net, state_dict
+            )
+            test_lycoris_from_weights.apply_to()
+            test_lycoris_from_weights.to(device, dtype)
+            test_output_from_weights = test_net(test_input)
 
-        test_lycoris_from_weights.load_state_dict(test_lycoris.state_dict())
+            test_lycoris_from_weights.load_state_dict(test_lycoris.state_dict())
 
-        self.assertTrue(len(test_lycoris.loras) == len(test_lycoris_from_weights.loras))
-        self.assertTrue(torch.allclose(test_output, test_output_from_weights))
+            self.assertTrue(len(test_lycoris.loras) == len(test_lycoris_from_weights.loras))
+            self.assertTrue(torch.allclose(test_output, test_output_from_weights))
+        finally:
+            reset_globals()
 
     def test_lycoris_wrapper_regex_named_modules(
         self,
         device_dtype=(torch.device("cpu"), torch.float32),
     ):
-        device, dtype = device_dtype
+        try:
+            device, dtype = device_dtype
 
-        # Define the preset configuration with regex
-        preset = {
-            "name_algo_map": {
-                "linear_layers.layers.[0-1]..*": {
-                    "algo": "lokr",
-                    "factor": 4,
-                    "linear_dim": 1000000,
-                    "linear_alpha": 1,
-                    "full_matrix": True,
-                },
-                "linear_layers.layers.2..*": {
-                    "algo": "lora",
-                    "dim": 8,
-                },
-                "conv_layers.layers.0..*": {
-                    "algo": "locon",
-                    "dim": 8,
-                },
-                "conv_layers.layers.[1-2]..*": {
-                    "algo": "glora",
-                    "dim": 128,
-                },
+            # Define the preset configuration with regex
+            preset = {
+                "name_algo_map": {
+                    "linear_layers.layers.[0-1]..*": {
+                        "algo": "lokr",
+                        "factor": 4,
+                        "linear_dim": 1000000,
+                        "linear_alpha": 1,
+                        "full_matrix": True,
+                    },
+                    "linear_layers.layers.2..*": {
+                        "algo": "lora",
+                        "dim": 8,
+                    },
+                    "conv_layers.layers.0..*": {
+                        "algo": "locon",
+                        "dim": 8,
+                    },
+                    "conv_layers.layers.[1-2]..*": {
+                        "algo": "glora",
+                        "dim": 128,
+                    },
+                }
             }
-        }
 
-        # Apply the preset to the LycorisNetwork class
-        LycorisNetwork.apply_preset(preset)
+            # Apply the preset to the LycorisNetwork class
+            LycorisNetwork.apply_preset(preset)
 
-        # Create the test network and the Lycoris network wrapper
-        test_net = TestNetwork2(16).to(device, dtype)
-        test_lycoris: LycorisNetwork = create_lycoris(
-            test_net,
-            multiplier=1,
-            linear_dim=16,
-            linear_alpha=1,
-            train_norm=True,
-        )
-        test_lycoris.apply_to()
-        test_lycoris.to(device, dtype)
+            # Create the test network and the Lycoris network wrapper
+            test_net = TestNetwork2(16).to(device, dtype)
+            test_lycoris: LycorisNetwork = create_lycoris(
+                test_net,
+                multiplier=1,
+                linear_dim=16,
+                linear_alpha=1,
+                train_norm=True,
+            )
+            test_lycoris.apply_to()
+            test_lycoris.to(device, dtype)
 
-        # Assertions to verify the correct modules were created and configured
-        assert len(test_lycoris.loras) == 12
+            # Assertions to verify the correct modules were created and configured
+            assert len(test_lycoris.loras) == 12
 
-        lora_names = sorted([lora.lora_name for lora in test_lycoris.loras])
-        expected = sorted(
-            [
-                "lycoris_linear_layers_layers_0_layer_norm",
-                "lycoris_linear_layers_layers_0_linear",
-                "lycoris_linear_layers_layers_1_layer_norm",
-                "lycoris_linear_layers_layers_1_linear",
-                "lycoris_linear_layers_layers_2_layer_norm",
-                "lycoris_linear_layers_layers_2_linear",
-                "lycoris_conv_layers_layers_0_layer_norm",
-                "lycoris_conv_layers_layers_0_conv",
-                "lycoris_conv_layers_layers_1_layer_norm",
-                "lycoris_conv_layers_layers_1_conv",
-                "lycoris_conv_layers_layers_2_layer_norm",
-                "lycoris_conv_layers_layers_2_conv",
-            ]
-        )
-        self.assertEqual(lora_names, expected)
+            lora_names = sorted([lora.lora_name for lora in test_lycoris.loras])
+            expected = sorted(
+                [
+                    "lycoris_linear_layers_layers_0_layer_norm",
+                    "lycoris_linear_layers_layers_0_linear",
+                    "lycoris_linear_layers_layers_1_layer_norm",
+                    "lycoris_linear_layers_layers_1_linear",
+                    "lycoris_linear_layers_layers_2_layer_norm",
+                    "lycoris_linear_layers_layers_2_linear",
+                    "lycoris_conv_layers_layers_0_layer_norm",
+                    "lycoris_conv_layers_layers_0_conv",
+                    "lycoris_conv_layers_layers_1_layer_norm",
+                    "lycoris_conv_layers_layers_1_conv",
+                    "lycoris_conv_layers_layers_2_layer_norm",
+                    "lycoris_conv_layers_layers_2_conv",
+                ]
+            )
+            self.assertEqual(lora_names, expected)
 
-        for lora in test_lycoris.loras:
-            if (
-                "lycoris_linear_layers_layers_0" in lora.lora_name
-                or "lycoris_linear_layers_layers_1" in lora.lora_name
-            ):
-                self.assertEqual(lora.dim, 16)
-                if "norm" in lora.lora_name:
-                    self.assertEqual(lora.__class__.__name__, "NormModule")
-                else:
-                    self.assertEqual(lora.__class__.__name__, "LokrModule")
-                    self.assertEqual(lora.multiplier, 1)
-                    self.assertEqual(lora.full_matrix, True)
-            elif "lycoris_linear_layers_layers_2" in lora.lora_name:
-                self.assertEqual(lora.dim, 16)
-                if "norm" in lora.lora_name:
-                    self.assertEqual(lora.__class__.__name__, "NormModule")
-                else:
-                    self.assertEqual(lora.__class__.__name__, "LoConModule")
-            elif "lycoris_conv_layers_layers_0" in lora.lora_name:
-                self.assertEqual(lora.dim, 16)
-                if "norm" in lora.lora_name:
-                    self.assertEqual(lora.__class__.__name__, "NormModule")
-                else:
-                    self.assertEqual(lora.__class__.__name__, "LoConModule")
-            elif (
-                "lycoris_linear_layers_layers_1" in lora.lora_name
-                or "lycoris_linear_layers_layers_2" in lora.lora_name
-            ):
-                self.assertEqual(lora.dim, 128)
-                if "norm" in lora.lora_name:
-                    self.assertEqual(lora.__class__.__name__, "NormModule")
-                else:
-                    self.assertEqual(lora.__class__.__name__, "GLoRAModule")
+            for lora in test_lycoris.loras:
+                if (
+                    "lycoris_linear_layers_layers_0" in lora.lora_name
+                    or "lycoris_linear_layers_layers_1" in lora.lora_name
+                ):
+                    self.assertEqual(lora.dim, 16)
+                    if "norm" in lora.lora_name:
+                        self.assertEqual(lora.__class__.__name__, "NormModule")
+                    else:
+                        self.assertEqual(lora.__class__.__name__, "LokrModule")
+                        self.assertEqual(lora.multiplier, 1)
+                        self.assertEqual(lora.full_matrix, True)
+                elif "lycoris_linear_layers_layers_2" in lora.lora_name:
+                    self.assertEqual(lora.dim, 16)
+                    if "norm" in lora.lora_name:
+                        self.assertEqual(lora.__class__.__name__, "NormModule")
+                    else:
+                        self.assertEqual(lora.__class__.__name__, "LoConModule")
+                elif "lycoris_conv_layers_layers_0" in lora.lora_name:
+                    self.assertEqual(lora.dim, 16)
+                    if "norm" in lora.lora_name:
+                        self.assertEqual(lora.__class__.__name__, "NormModule")
+                    else:
+                        self.assertEqual(lora.__class__.__name__, "LoConModule")
+                elif (
+                    "lycoris_linear_layers_layers_1" in lora.lora_name
+                    or "lycoris_linear_layers_layers_2" in lora.lora_name
+                ):
+                    self.assertEqual(lora.dim, 128)
+                    if "norm" in lora.lora_name:
+                        self.assertEqual(lora.__class__.__name__, "NormModule")
+                    else:
+                        self.assertEqual(lora.__class__.__name__, "GLoRAModule")
+
+        finally:
+            reset_globals()
+
+    def test_diffusers_models_and_state_dicts_single_blocks(self):
+        try:
+            transformer = FluxTransformer2DModel.from_config(
+                {
+                    "attention_head_dim": 128,
+                    "guidance_embeds": True,
+                    "in_channels": 64,
+                    "joint_attention_dim": 4096,
+                    "num_attention_heads": 24,
+                    "num_layers": 2,
+                    "num_single_layers": 2,
+                    "patch_size": 1,
+                    "pooled_projection_dim": 768,
+                }
+            )
+
+            # Apply the preset to the LycorisNetwork class
+            LycorisNetwork.apply_preset({
+                "target_module": [
+                    "FluxTransformerBlock",
+                    "FluxSingleTransformerBlock"
+                ],
+                "module_algo_map": {
+                    "Attention": {
+                        "factor": 16
+                    },
+                    "FeedForward": {
+                        "factor": 8
+                    }
+                }
+            })
+
+            # Create the test network and the Lycoris network wrapper
+            test_lycoris: LycorisNetwork = create_lycoris(
+                transformer,
+                algo="lokr",
+                multiplier=1.0,
+                linear_dim=10000,
+                linear_alpha=1,
+                factor=16,
+            )
+            test_lycoris.apply_to()
+
+            state_dict = test_lycoris.state_dict()
+            assert sorted([
+                'lycoris_transformer_blocks_0_norm1_linear.alpha',
+                'lycoris_transformer_blocks_0_norm1_linear.lokr_w1',
+                'lycoris_transformer_blocks_0_norm1_linear.lokr_w2',
+                'lycoris_transformer_blocks_0_norm1_context_linear.alpha',
+                'lycoris_transformer_blocks_0_norm1_context_linear.lokr_w1',
+                'lycoris_transformer_blocks_0_norm1_context_linear.lokr_w2',
+                'lycoris_transformer_blocks_1_norm1_linear.alpha',
+                'lycoris_transformer_blocks_1_norm1_linear.lokr_w1',
+                'lycoris_transformer_blocks_1_norm1_linear.lokr_w2',
+                'lycoris_transformer_blocks_1_norm1_context_linear.alpha',
+                'lycoris_transformer_blocks_1_norm1_context_linear.lokr_w1',
+                'lycoris_transformer_blocks_1_norm1_context_linear.lokr_w2',
+                'lycoris_single_transformer_blocks_0_norm_linear.alpha',
+                'lycoris_single_transformer_blocks_0_norm_linear.lokr_w1',
+                'lycoris_single_transformer_blocks_0_norm_linear.lokr_w2',
+                'lycoris_single_transformer_blocks_0_proj_mlp.alpha',
+                'lycoris_single_transformer_blocks_0_proj_mlp.lokr_w1',
+                'lycoris_single_transformer_blocks_0_proj_mlp.lokr_w2',
+                'lycoris_single_transformer_blocks_0_proj_out.alpha',
+                'lycoris_single_transformer_blocks_0_proj_out.lokr_w1',
+                'lycoris_single_transformer_blocks_0_proj_out.lokr_w2',
+                'lycoris_single_transformer_blocks_1_norm_linear.alpha',
+                'lycoris_single_transformer_blocks_1_norm_linear.lokr_w1',
+                'lycoris_single_transformer_blocks_1_norm_linear.lokr_w2',
+                'lycoris_single_transformer_blocks_1_proj_mlp.alpha',
+                'lycoris_single_transformer_blocks_1_proj_mlp.lokr_w1',
+                'lycoris_single_transformer_blocks_1_proj_mlp.lokr_w2',
+                'lycoris_single_transformer_blocks_1_proj_out.alpha',
+                'lycoris_single_transformer_blocks_1_proj_out.lokr_w1',
+                'lycoris_single_transformer_blocks_1_proj_out.lokr_w2',
+            ]) == sorted([k for k in state_dict.keys()])
+
+            state_dict = test_lycoris.state_dict()
+            test_lycoris_from_weights: LycorisNetwork
+            test_lycoris_from_weights, _ = create_lycoris_from_weights(
+                1, None, transformer, state_dict
+            )
+            test_lycoris_from_weights.apply_to()
+            test_lycoris_from_weights.load_state_dict(test_lycoris.state_dict())
+
+            self.assertTrue(len(test_lycoris.loras) == len(test_lycoris_from_weights.loras))
+            for lora, lora_loaded in zip(test_lycoris.loras, test_lycoris_from_weights.loras):
+                lora_sd = lora.state_dict()
+                lora_loaded_sd = lora_loaded.state_dict()
+                assert torch.equal(lora_sd['alpha'], lora_loaded_sd['alpha'])
+                assert torch.equal(lora_sd['lokr_w1'], lora_loaded_sd['lokr_w1'])
+                assert torch.equal(lora_sd['lokr_w2'], lora_loaded_sd['lokr_w2'])
+        finally:
+            reset_globals()
+
+    def test_diffusers_models_and_state_dicts_whole_model(self):
+        try:
+            transformer = FluxTransformer2DModel.from_config(
+                {
+                    "attention_head_dim": 128,
+                    "guidance_embeds": True,
+                    "in_channels": 64,
+                    "joint_attention_dim": 4096,
+                    "num_attention_heads": 24,
+                    "num_layers": 1,
+                    "num_single_layers": 1,
+                    "patch_size": 1,
+                    "pooled_projection_dim": 768,
+                }
+            )
+
+            # Apply the preset to the LycorisNetwork class
+            LycorisNetwork.apply_preset({
+                "module_algo_map": {
+                    "FluxTransformer2DModel": {
+                        "factor": 16
+                    }
+                }
+            })
+
+            # Create the test network and the Lycoris network wrapper
+            test_lycoris: LycorisNetwork = create_lycoris(
+                transformer,
+                algo="lokr",
+                multiplier=1.0,
+                linear_dim=10000,
+                linear_alpha=1,
+                factor=16,
+            )
+            test_lycoris.apply_to()
+
+            state_dict = test_lycoris.state_dict()
+            assert sorted([
+                "lycoris_time_text_embed_timestep_embedder_linear_1.alpha",
+                "lycoris_time_text_embed_timestep_embedder_linear_1.lokr_w1",
+                "lycoris_time_text_embed_timestep_embedder_linear_1.lokr_w2",
+                "lycoris_time_text_embed_timestep_embedder_linear_2.alpha",
+                "lycoris_time_text_embed_timestep_embedder_linear_2.lokr_w1",
+                "lycoris_time_text_embed_timestep_embedder_linear_2.lokr_w2",
+                "lycoris_time_text_embed_guidance_embedder_linear_1.alpha",
+                "lycoris_time_text_embed_guidance_embedder_linear_1.lokr_w1",
+                "lycoris_time_text_embed_guidance_embedder_linear_1.lokr_w2",
+                "lycoris_time_text_embed_guidance_embedder_linear_2.alpha",
+                "lycoris_time_text_embed_guidance_embedder_linear_2.lokr_w1",
+                "lycoris_time_text_embed_guidance_embedder_linear_2.lokr_w2",
+                "lycoris_time_text_embed_text_embedder_linear_1.alpha",
+                "lycoris_time_text_embed_text_embedder_linear_1.lokr_w1",
+                "lycoris_time_text_embed_text_embedder_linear_1.lokr_w2",
+                "lycoris_time_text_embed_text_embedder_linear_2.alpha",
+                "lycoris_time_text_embed_text_embedder_linear_2.lokr_w1",
+                "lycoris_time_text_embed_text_embedder_linear_2.lokr_w2",
+                "lycoris_context_embedder.alpha",
+                "lycoris_context_embedder.lokr_w1",
+                "lycoris_context_embedder.lokr_w2",
+                "lycoris_x_embedder.alpha",
+                "lycoris_x_embedder.lokr_w1",
+                "lycoris_x_embedder.lokr_w2",
+                "lycoris_transformer_blocks_0_norm1_linear.alpha",
+                "lycoris_transformer_blocks_0_norm1_linear.lokr_w1",
+                "lycoris_transformer_blocks_0_norm1_linear.lokr_w2",
+                "lycoris_transformer_blocks_0_norm1_context_linear.alpha",
+                "lycoris_transformer_blocks_0_norm1_context_linear.lokr_w1",
+                "lycoris_transformer_blocks_0_norm1_context_linear.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_to_q.alpha",
+                "lycoris_transformer_blocks_0_attn_to_q.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_to_q.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_to_k.alpha",
+                "lycoris_transformer_blocks_0_attn_to_k.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_to_k.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_to_v.alpha",
+                "lycoris_transformer_blocks_0_attn_to_v.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_to_v.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_add_k_proj.alpha",
+                "lycoris_transformer_blocks_0_attn_add_k_proj.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_add_k_proj.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_add_v_proj.alpha",
+                "lycoris_transformer_blocks_0_attn_add_v_proj.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_add_v_proj.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_add_q_proj.alpha",
+                "lycoris_transformer_blocks_0_attn_add_q_proj.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_add_q_proj.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_to_out_0.alpha",
+                "lycoris_transformer_blocks_0_attn_to_out_0.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_to_out_0.lokr_w2",
+                "lycoris_transformer_blocks_0_attn_to_add_out.alpha",
+                "lycoris_transformer_blocks_0_attn_to_add_out.lokr_w1",
+                "lycoris_transformer_blocks_0_attn_to_add_out.lokr_w2",
+                "lycoris_transformer_blocks_0_ff_net_0_proj.alpha",
+                "lycoris_transformer_blocks_0_ff_net_0_proj.lokr_w1",
+                "lycoris_transformer_blocks_0_ff_net_0_proj.lokr_w2",
+                "lycoris_transformer_blocks_0_ff_net_2.alpha",
+                "lycoris_transformer_blocks_0_ff_net_2.lokr_w1",
+                "lycoris_transformer_blocks_0_ff_net_2.lokr_w2",
+                "lycoris_transformer_blocks_0_ff_context_net_0_proj.alpha",
+                "lycoris_transformer_blocks_0_ff_context_net_0_proj.lokr_w1",
+                "lycoris_transformer_blocks_0_ff_context_net_0_proj.lokr_w2",
+                "lycoris_transformer_blocks_0_ff_context_net_2.alpha",
+                "lycoris_transformer_blocks_0_ff_context_net_2.lokr_w1",
+                "lycoris_transformer_blocks_0_ff_context_net_2.lokr_w2",
+                "lycoris_single_transformer_blocks_0_norm_linear.alpha",
+                "lycoris_single_transformer_blocks_0_norm_linear.lokr_w1",
+                "lycoris_single_transformer_blocks_0_norm_linear.lokr_w2",
+                "lycoris_single_transformer_blocks_0_proj_mlp.alpha",
+                "lycoris_single_transformer_blocks_0_proj_mlp.lokr_w1",
+                "lycoris_single_transformer_blocks_0_proj_mlp.lokr_w2",
+                "lycoris_single_transformer_blocks_0_proj_out.alpha",
+                "lycoris_single_transformer_blocks_0_proj_out.lokr_w1",
+                "lycoris_single_transformer_blocks_0_proj_out.lokr_w2",
+                "lycoris_single_transformer_blocks_0_attn_to_q.alpha",
+                "lycoris_single_transformer_blocks_0_attn_to_q.lokr_w1",
+                "lycoris_single_transformer_blocks_0_attn_to_q.lokr_w2",
+                "lycoris_single_transformer_blocks_0_attn_to_k.alpha",
+                "lycoris_single_transformer_blocks_0_attn_to_k.lokr_w1",
+                "lycoris_single_transformer_blocks_0_attn_to_k.lokr_w2",
+                "lycoris_single_transformer_blocks_0_attn_to_v.alpha",
+                "lycoris_single_transformer_blocks_0_attn_to_v.lokr_w1",
+                "lycoris_single_transformer_blocks_0_attn_to_v.lokr_w2",
+                "lycoris_norm_out_linear.alpha",
+                "lycoris_norm_out_linear.lokr_w1",
+                "lycoris_norm_out_linear.lokr_w2",
+                "lycoris_proj_out.alpha",
+                "lycoris_proj_out.lokr_w1",
+                "lycoris_proj_out.lokr_w2"
+            ]) == sorted([k for k in state_dict.keys()])
+
+            state_dict = test_lycoris.state_dict()
+            test_lycoris_from_weights: LycorisNetwork
+            test_lycoris_from_weights, _ = create_lycoris_from_weights(
+                1, None, transformer, state_dict
+            )
+            test_lycoris_from_weights.apply_to()
+            test_lycoris_from_weights.load_state_dict(test_lycoris.state_dict())
+
+            self.assertTrue(len(test_lycoris.loras) == len(test_lycoris_from_weights.loras))
+            for lora, lora_loaded in zip(test_lycoris.loras, test_lycoris_from_weights.loras):
+                lora_sd = lora.state_dict()
+                lora_loaded_sd = lora_loaded.state_dict()
+                assert torch.equal(lora_sd['alpha'], lora_loaded_sd['alpha'])
+                assert torch.equal(lora_sd['lokr_w1'], lora_loaded_sd['lokr_w1'])
+                assert torch.equal(lora_sd['lokr_w2'], lora_loaded_sd['lokr_w2'])
+        finally:
+            reset_globals()
+
+    def test_diffusers_models_and_state_dicts_fnmatch(self):
+        try:
+            transformer = FluxTransformer2DModel.from_config(
+                {
+                    "attention_head_dim": 128,
+                    "guidance_embeds": True,
+                    "in_channels": 64,
+                    "joint_attention_dim": 4096,
+                    "num_attention_heads": 24,
+                    "num_layers": 4,
+                    "num_single_layers": 4,
+                    "patch_size": 1,
+                    "pooled_projection_dim": 768,
+                }
+            )
+
+            # Apply the preset to the LycorisNetwork class
+            LycorisNetwork.apply_preset({
+                "target_module": [
+                    "FluxTransformerBlock",
+                    "FluxSingleTransformerBlock"
+                ],
+                "name_algo_map": {
+                    "transformer_blocks.[2-3]*": {
+                        "algo": "lokr",
+                        "factor": 8,
+                        "linear_alpha": 1,
+                        "full_matrix": True
+                    },
+                    "single_transformer_blocks.[1-3]*": {
+                        "algo": "lokr",
+                        "factor": 12,
+                        "linear_alpha": 1,
+                        "full_matrix": True
+                    },
+                },
+                'use_fnmatch': True,
+            })
+
+            # Create the test network and the Lycoris network wrapper
+            test_lycoris: LycorisNetwork = create_lycoris(
+                transformer,
+                algo="lokr",
+                multiplier=1.0,
+                linear_alpha=1,
+                factor=16,
+                full_matrix=True,
+            )
+            test_lycoris.apply_to()
+
+            def check_dims(lora, factor):
+                lokr_w2_shape = lora.state_dict()['lokr_w2'].shape
+                return lora.shape[0] // lokr_w2_shape[0] == factor
+
+            for lora in test_lycoris.loras:
+                if (
+                    "lycoris_transformer_blocks_0" in lora.lora_name
+                    or "lycoris_transformer_blocks_1" in lora.lora_name
+                ):
+                    self.assertTrue(check_dims(lora, 16))
+                elif (
+                    "lycoris_transformer_blocks_2" in lora.lora_name
+                    or "lycoris_transformer_blocks_3" in lora.lora_name
+                ):
+                    self.assertTrue(check_dims(lora, 8))
+                elif (
+                    "lycoris_single_transformer_blocks_0" in lora.lora_name
+                ):
+                    self.assertTrue(check_dims(lora, 16))
+                elif (
+                    "lycoris_single_transformer_blocks_1" in lora.lora_name
+                    or "lycoris_single_transformer_blocks_2" in lora.lora_name
+                    or "lycoris_single_transformer_blocks_3" in lora.lora_name
+                ):
+                    self.assertTrue(check_dims(lora, 12))
+
+            test_lycoris_from_weights: LycorisNetwork
+            test_lycoris_from_weights, _ = create_lycoris_from_weights(
+                1, None, transformer, test_lycoris.state_dict()
+            )
+            test_lycoris_from_weights.apply_to()
+            test_lycoris_from_weights.load_state_dict(test_lycoris.state_dict())
+
+            self.assertTrue(len(test_lycoris.loras) == len(test_lycoris_from_weights.loras))
+            for lora, lora_loaded in zip(test_lycoris.loras, test_lycoris_from_weights.loras):
+                lora_sd = lora.state_dict()
+                lora_loaded_sd = lora_loaded.state_dict()
+                assert torch.equal(lora_sd['alpha'], lora_loaded_sd['alpha'])
+                assert torch.equal(lora_sd['lokr_w1'], lora_loaded_sd['lokr_w1'])
+                assert torch.equal(lora_sd['lokr_w2'], lora_loaded_sd['lokr_w2'])
+
+        finally:
+            reset_globals()
+
+    def test_diffusers_models_and_state_dicts_fnmatch_and_exclude(self):
+        try:
+            transformer = FluxTransformer2DModel.from_config(
+                {
+                    "attention_head_dim": 128,
+                    "guidance_embeds": True,
+                    "in_channels": 64,
+                    "joint_attention_dim": 4096,
+                    "num_attention_heads": 24,
+                    "num_layers": 4,
+                    "num_single_layers": 4,
+                    "patch_size": 1,
+                    "pooled_projection_dim": 768,
+                }
+            )
+
+            # Apply the preset to the LycorisNetwork class
+            LycorisNetwork.apply_preset({
+                "target_module": [
+                    "FluxTransformerBlock",
+                    "FluxSingleTransformerBlock"
+                ],
+                "name_algo_map": {
+                    "transformer_blocks.[2-3]*": {
+                        "algo": "lokr",
+                        "factor": 8,
+                        "linear_alpha": 1,
+                        "full_matrix": True
+                    },
+                    "single_transformer_blocks.[1-3]*": {
+                        "algo": "lokr",
+                        "factor": 12,
+                        "linear_alpha": 1,
+                        "full_matrix": True
+                    },
+                },
+                'use_fnmatch': True,
+                'exclude_name': [
+                    'transformer_blocks.1*',
+                    'single_transformer_blocks.[2-3]*',
+                ]
+            })
+
+            # Create the test network and the Lycoris network wrapper
+            test_lycoris: LycorisNetwork = create_lycoris(
+                transformer,
+                algo="lokr",
+                multiplier=1.0,
+                linear_alpha=1,
+                factor=16,
+                full_matrix=True,
+            )
+            test_lycoris.apply_to()
+
+            def check_dims(lora, factor):
+                lokr_w2_shape = lora.state_dict()['lokr_w2'].shape
+                return lora.shape[0] // lokr_w2_shape[0] == factor
+
+            for lora in test_lycoris.loras:
+                assert "lycoris_transformer_blocks_1" not in lora.lora_name
+                assert "lycoris_single_transformer_blocks_2" not in lora.lora_name
+                assert "lycoris_single_transformer_blocks_3" not in lora.lora_name
+                if  "lycoris_transformer_blocks_0" in lora.lora_name:
+                    self.assertTrue(check_dims(lora, 16))
+                elif (
+                    "lycoris_transformer_blocks_2" in lora.lora_name
+                    or "lycoris_transformer_blocks_3" in lora.lora_name
+                ):
+                    self.assertTrue(check_dims(lora, 8))
+                elif (
+                    "lycoris_single_transformer_blocks_0" in lora.lora_name
+                ):
+                    self.assertTrue(check_dims(lora, 16))
+                elif "lycoris_single_transformer_blocks_1" in lora.lora_name:
+                    self.assertTrue(check_dims(lora, 12))
+
+            test_lycoris_from_weights: LycorisNetwork
+            test_lycoris_from_weights, _ = create_lycoris_from_weights(
+                1, None, transformer, test_lycoris.state_dict()
+            )
+            test_lycoris_from_weights.apply_to()
+            test_lycoris_from_weights.load_state_dict(test_lycoris.state_dict())
+
+            self.assertTrue(len(test_lycoris.loras) == len(test_lycoris_from_weights.loras))
+            for lora, lora_loaded in zip(test_lycoris.loras, test_lycoris_from_weights.loras):
+                lora_sd = lora.state_dict()
+                lora_loaded_sd = lora_loaded.state_dict()
+                assert torch.equal(lora_sd['alpha'], lora_loaded_sd['alpha'])
+                assert torch.equal(lora_sd['lokr_w1'], lora_loaded_sd['lokr_w1'])
+                assert torch.equal(lora_sd['lokr_w2'], lora_loaded_sd['lokr_w2'])
+
+        finally:
+            reset_globals()


### PR DESCRIPTION
- Add fnmatch module name matching for wrapper.py and kohya.py
- Add 'exclude_name' to wrapper to exclude named modules
- Add preset key sanity matching to wrapper apply_preset fn
- Fix compatibility bug with previous version where it duplicated layers
- Add extensive tests for diffusers and flux networks, along with all new features