### PR TITLE
Fix issues with boft/diag-oft loading via create_lycoris_from_weights()

### DIFF
--- a/lycoris/modules/boft.py
+++ b/lycoris/modules/boft.py
@@ -116,10 +116,13 @@ class ButterflyOFTModule(LycorisBaseModule):
             lora_name,
             orig_module,
             1,
-            lora_dim=n,
-            alpha=float(alpha),
-            rescale=rescale is not None,
+            lora_dim=s,
+            constraint=float(alpha),
+            rescaled=rescale is not None,
         )
+        module.oft_blocks.copy_(oft_blocks)
+        if rescale is not None:
+            module.rescale.copy_(rescale)
         return module
 
     @property

--- a/lycoris/modules/diag_oft.py
+++ b/lycoris/modules/diag_oft.py
@@ -104,9 +104,12 @@ class DiagOFTModule(LycorisBaseModule):
             orig_module,
             1,
             lora_dim=s,
-            alpha=float(alpha),
-            rescale=rescale is not None,
+            constraint=float(alpha),
+            rescaled=rescale is not None,
         )
+        module.oft_blocks.copy_(oft_blocks)
+        if rescale is not None:
+            module.rescale.copy_(rescale)
         return module
 
     @property


### PR DESCRIPTION
This pull request fixes multiple issues I encountered when trying to get BOFT / Diag-OFT working.

1. BOFT is loaded with wrong factor. My original training run created the BOFT with factor 8 (that was rounded down to 6):

```
2024-09-21 02:24:10,488 [INFO] Using lycoris training mode
2024-09-21 02:24:10|[LyCORIS]-INFO: Using rank adaptation algo: boft
2024-09-21 02:24:10|[LyCORIS]-INFO: Use Dropout value: 0.0
2024-09-21 02:24:10|[LyCORIS]-INFO: Create LyCORIS Module
2024-09-21 02:24:10|[LyCORIS]-WARNING: Using bnb/quanto/optimum-quanto with LyCORIS will enable force-bypass mode.
2024-09-21 02:24:10|[LyCORIS]-INFO: Use BOFT(9, 3) (equivalent to factor=6) for dim=3072 and factor=8
2024-09-21 02:24:10|[LyCORIS]-INFO: Use BOFT(11, 3) (equivalent to factor=6) for dim=12288 and factor=8
2024-09-21 02:24:10|[LyCORIS]-INFO: create LyCORIS: 342 modules.
2024-09-21 02:24:10|[LyCORIS]-INFO: module type table: {'ButterflyOFTModule': 342}
2024-09-21 02:24:10,566 [INFO] LyCORIS network has been initialized with 89,653,248 parameters
```

When trying to resume training using --init-lora in SimpleTuner, I noticed the factor was much higher:

```
2024-09-21 12:50:14,878 [INFO] Using lycoris training mode
2024-09-21 12:50:15|[LyCORIS]-INFO: Loading Modules from state dict...
2024-09-21 12:50:15|[LyCORIS]-WARNING: Using bnb/quanto/optimum-quanto with LyCORIS will enable force-bypass mode.
2024-09-21 12:50:15|[LyCORIS]-INFO: Use BOFT(3, 192) (equivalent to factor=384) for dim=3072 and factor=512
2024-09-21 12:50:15|[LyCORIS]-INFO: Use BOFT(3, 768) (equivalent to factor=1536) for dim=12288 and factor=2048
2024-09-21 12:50:16|[LyCORIS]-INFO: 342 Modules Loaded
2024-09-21 12:50:16,321 [INFO] LyCORIS network has been initialized with 4,303,355,904 parameters
```

The fix is to read the factor from `s` (i.e. `oft_blocks.shape[2]`) instead of `n` (i.e. `oft_blocks.shape[1]`).
```
oft_blocks.shape = torch.Size([10, 512, 6, 6])
oft_blocks.shape = torch.Size([12, 2048, 6, 6])
```

2. The `oft_blocks` and `rescale` weights were not copied into the modules. I tested that the `oft_blocks` weights are getting properly loaded both by SimpleTuner and a simple inference script.

3. `alpha` should be passed as `constraint` to the initializer and `rescale` boolean should be passed as `rescaled`. I haven't tested these but they should work in theory.