### PR TITLE
Use correct weight decomposition by default

### DIFF
--- a/lycoris/kohya.py
+++ b/lycoris/kohya.py
@@ -57,7 +57,7 @@ def create_network(
     constraint = float(kwargs.get("constraint", None) or 0)
     rescaled = str_bool(kwargs.get("rescaled", False))
     weight_decompose = str_bool(kwargs.get("dora_wd", False))
-    wd_on_output = str_bool(kwargs.get("wd_on_output", False))
+    wd_on_output = str_bool(kwargs.get("wd_on_output", True))
     full_matrix = str_bool(kwargs.get("full_matrix", False))
     bypass_mode = str_bool(kwargs.get("bypass_mode", None))
     rs_lora = str_bool(kwargs.get("rs_lora", False))

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -49,7 +49,7 @@ class LoConModule(LycorisBaseModule):
         use_scalar=False,
         rank_dropout_scale=False,
         weight_decompose=False,
-        wd_on_out=False,
+        wd_on_out=True,
         bypass_mode=None,
         rs_lora=False,
         **kwargs,

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -41,7 +41,7 @@ class LohaModule(LycorisBaseModule):
         use_scalar=False,
         rank_dropout_scale=False,
         weight_decompose=False,
-        wd_on_out=False,
+        wd_on_out=True,
         bypass_mode=None,
         rs_lora=False,
         **kwargs,

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -58,7 +58,7 @@ class LokrModule(LycorisBaseModule):
         factor: int = -1,  # factorization factor
         rank_dropout_scale=False,
         weight_decompose=False,
-        wd_on_out=False,
+        wd_on_out=True,
         full_matrix=False,
         bypass_mode=None,
         rs_lora=False,

--- a/lycoris/wrapper.py
+++ b/lycoris/wrapper.py
@@ -89,7 +89,7 @@ def create_lycoris(module, multiplier=1.0, linear_dim=4, linear_alpha=1, **kwarg
     constraint = float(kwargs.get("constraint", 0) or 0)
     rescaled = str_bool(kwargs.get("rescaled", False))
     weight_decompose = str_bool(kwargs.get("dora_wd", False))
-    wd_on_output = str_bool(kwargs.get("wd_on_output", False))
+    wd_on_output = str_bool(kwargs.get("wd_on_output", True))
     full_matrix = str_bool(kwargs.get("full_matrix", False))
     bypass_mode = str_bool(kwargs.get("bypass_mode", None))
     unbalanced_factorization = str_bool(kwargs.get("unbalanced_factorization", False))


### PR DESCRIPTION
Title. In accordance with: https://github.com/KohakuBlueleaf/LyCORIS?tab=readme-ov-file#20241209-update-to-311

I don't see why we should be using the incorrect implementation by default, so this PR corrects that.