### PR TITLE
LoHA: option to follow paper formula with constant bias

### DIFF
--- a/docs/Network-Args.md
+++ b/docs/Network-Args.md
@@ -79,6 +79,13 @@ Arguments to put in `network_args` for kohya sd scripts
 * Use $Y = WX + \Delta WX$  instead of $Y=(W+\Delta W)X$
 * Designed for bnb 8bit/4bit linear layer. (QLyCORIS)
 
+### Constant Bias
+
+- Enabled with `use_constant_bias=True`
+- Valid for LoHa
+- Changes the Hadamard product from `(W1) * (W2)` to `(W1) * (1 + W2)`, matching the original FedPara paper's formulation
+- When W2 is zero-initialized, this makes the initial delta equal to W1 rather than zero
+
 ### Normalization Layers
 
 - Enabled with `train_norm=True`

--- a/lycoris/config_sdk.py
+++ b/lycoris/config_sdk.py
@@ -81,6 +81,7 @@ ALGO_REGISTRY: Dict[str, AlgoSpec] = {
             "use_scalar",
             "weight_decompose",
             "wd_on_output",
+            "use_constant_bias",
         ),
         notes="High dimensions may require lower learning rates to remain stable.",
     ),

--- a/lycoris/functional/loha.py
+++ b/lycoris/functional/loha.py
@@ -9,16 +9,23 @@ from .general import FUNC_LIST
 
 class HadaWeight(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, w1d, w1u, w2d, w2u, scale=torch.tensor(1)):
+    def forward(ctx, w1d, w1u, w2d, w2u, scale=torch.tensor(1), constant_bias=False):
         ctx.save_for_backward(w1d, w1u, w2d, w2u, scale)
-        diff_weight = ((w1u @ w1d) * (w2u @ w2d)) * scale
+        ctx.constant_bias = constant_bias
+        rebuild2 = w2u @ w2d
+        if constant_bias:
+            rebuild2 = 1 + rebuild2
+        diff_weight = ((w1u @ w1d) * rebuild2) * scale
         return diff_weight
 
     @staticmethod
     def backward(ctx, grad_out):
         (w1d, w1u, w2d, w2u, scale) = ctx.saved_tensors
         grad_out = grad_out * scale
-        temp = grad_out * (w2u @ w2d)
+        rebuild2 = w2u @ w2d
+        if ctx.constant_bias:
+            rebuild2 = 1 + rebuild2
+        temp = grad_out * rebuild2
         grad_w1u = temp @ w1d.T
         grad_w1d = w1u.T @ temp
 
@@ -27,16 +34,20 @@ class HadaWeight(torch.autograd.Function):
         grad_w2d = w2u.T @ temp
 
         del temp
-        return grad_w1d, grad_w1u, grad_w2d, grad_w2u, None
+        return grad_w1d, grad_w1u, grad_w2d, grad_w2u, None, None
 
 
 class HadaWeightTucker(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, t1, w1d, w1u, t2, w2d, w2u, scale=torch.tensor(1)):
+    def forward(ctx, t1, w1d, w1u, t2, w2d, w2u, scale=torch.tensor(1), constant_bias=False):
         ctx.save_for_backward(t1, w1d, w1u, t2, w2d, w2u, scale)
+        ctx.constant_bias = constant_bias
 
         rebuild1 = torch.einsum("i j ..., j r, i p -> p r ...", t1, w1d, w1u)
         rebuild2 = torch.einsum("i j ..., j r, i p -> p r ...", t2, w2d, w2u)
+
+        if constant_bias:
+            rebuild2 = 1 + rebuild2
 
         return rebuild1 * rebuild2 * scale
 
@@ -47,6 +58,9 @@ class HadaWeightTucker(torch.autograd.Function):
 
         temp = torch.einsum("i j ..., j r -> i r ...", t2, w2d)
         rebuild = torch.einsum("i j ..., i r -> r j ...", temp, w2u)
+
+        if ctx.constant_bias:
+            rebuild = 1 + rebuild
 
         grad_w = rebuild * grad_out
         del rebuild
@@ -72,15 +86,15 @@ class HadaWeightTucker(torch.autograd.Function):
         grad_w2d = torch.einsum("i r ..., i j ... -> r j", t2, grad_temp)
         grad_t2 = torch.einsum("i j ..., j r -> i r ...", grad_temp, w2d.T)
         del grad_temp
-        return grad_t1, grad_w1d, grad_w1u, grad_t2, grad_w2d, grad_w2u, None
+        return grad_t1, grad_w1d, grad_w1u, grad_t2, grad_w2d, grad_w2u, None, None
 
 
-def make_weight(w1d, w1u, w2d, w2u, scale):
-    return HadaWeight.apply(w1d, w1u, w2d, w2u, scale)
+def make_weight(w1d, w1u, w2d, w2u, scale, constant_bias=False):
+    return HadaWeight.apply(w1d, w1u, w2d, w2u, scale, constant_bias)
 
 
-def make_weight_tucker(t1, w1d, w1u, t2, w2d, w2u, scale):
-    return HadaWeightTucker.apply(t1, w1d, w1u, t2, w2d, w2u, scale)
+def make_weight_tucker(t1, w1d, w1u, t2, w2d, w2u, scale, constant_bias=False):
+    return HadaWeightTucker.apply(t1, w1d, w1u, t2, w2d, w2u, scale, constant_bias)
 
 
 def weight_gen(org_weight, rank, tucker=True):
@@ -116,7 +130,7 @@ def weight_gen(org_weight, rank, tucker=True):
     return w1d, w1u, w2d, w2u, t1, t2
 
 
-def diff_weight(*weights, gamma=1.0):
+def diff_weight(*weights, gamma=1.0, constant_bias=False):
     """### diff_weight
 
     Get ΔW = BA, where BA is low rank decomposition
@@ -124,6 +138,7 @@ def diff_weight(*weights, gamma=1.0):
     Args:
         wegihts (tuple[torch.Tensor]): (w1d, w2d, w1u, w2u[, t1, t2])
         gamma (float, optional): scale factor, normally alpha/rank here
+        constant_bias (bool, optional): if True, use (W1) * (1 + W2) formulation
 
     Returns:
         torch.Tensor: ΔW
@@ -133,7 +148,7 @@ def diff_weight(*weights, gamma=1.0):
         R, I = w1d.shape
         R, O = w1u.shape
         R, R, *k = t1.shape
-        result = make_weight_tucker(t1, w1d, w1u, t2, w2d, w2u, gamma)
+        result = make_weight_tucker(t1, w1d, w1u, t2, w2d, w2u, gamma, constant_bias)
     else:
         R, I, *k = w1d.shape
         O, R, *_ = w1u.shape
@@ -141,7 +156,7 @@ def diff_weight(*weights, gamma=1.0):
         w1u = w1u.reshape(-1, w1u.size(1))
         w2d = w2d.reshape(w2d.size(0), -1)
         w2u = w2u.reshape(-1, w2u.size(1))
-        result = make_weight(w1d, w1u, w2d, w2u, gamma)
+        result = make_weight(w1d, w1u, w2d, w2u, gamma, constant_bias)
 
     result = result.reshape(O, I, *k)
     return result

--- a/lycoris/kohya.py
+++ b/lycoris/kohya.py
@@ -62,6 +62,7 @@ def create_network(
     bypass_mode = str_bool(kwargs.get("bypass_mode", False))
     rs_lora = str_bool(kwargs.get("rs_lora", False))
     unbalanced_factorization = str_bool(kwargs.get("unbalanced_factorization", False))
+    use_constant_bias = str_bool(kwargs.get("use_constant_bias", False))
     train_t5xxl = str_bool(kwargs.get("train_t5xxl", False))
     # lora_plus
     loraplus_lr_ratio = (
@@ -131,6 +132,7 @@ def create_network(
         bypass_mode=bypass_mode,
         rs_lora=rs_lora,
         unbalanced_factorization=unbalanced_factorization,
+        use_constant_bias=use_constant_bias,
         train_t5xxl=train_t5xxl,
         warn_on_unmatched=warn_on_unmatched,
     )

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -24,6 +24,7 @@ class LohaModule(LycorisBaseModule):
         "hada_t2",
         "alpha",
         "dora_scale",
+        "use_constant_bias",
     ]
     weight_list_det = ["hada_w1_a"]
 
@@ -44,6 +45,7 @@ class LohaModule(LycorisBaseModule):
         wd_on_out=True,
         bypass_mode=None,
         rs_lora=False,
+        use_constant_bias=False,
         **kwargs,
     ):
         super().__init__(
@@ -62,6 +64,7 @@ class LohaModule(LycorisBaseModule):
         self.lora_dim = lora_dim
         self.tucker = False
         self.rs_lora = rs_lora
+        self.use_constant_bias = use_constant_bias
 
         w_shape = self.shape
         if self.module_type.startswith("conv"):
@@ -155,7 +158,8 @@ class LohaModule(LycorisBaseModule):
 
     @classmethod
     def make_module_from_state_dict(
-        cls, lora_name, orig_module, w1a, w1b, w2a, w2b, t1, t2, alpha, dora_scale
+        cls, lora_name, orig_module, w1a, w1b, w2a, w2b, t1, t2, alpha, dora_scale,
+        use_constant_bias=None,
     ):
         module = cls(
             lora_name,
@@ -165,6 +169,7 @@ class LohaModule(LycorisBaseModule):
             float(alpha),
             use_tucker=t1 is not None,
             weight_decompose=dora_scale is not None,
+            use_constant_bias=use_constant_bias is not None and bool(use_constant_bias),
         )
         module.hada_w1_a.copy_(w1a)
         module.hada_w1_b.copy_(w1b)
@@ -204,6 +209,7 @@ class LohaModule(LycorisBaseModule):
                 self.hada_t1,
                 self.hada_t2,
                 gamma=scale,
+                constant_bias=self.use_constant_bias,
             )
         else:
             weight = loha_diff_weight(
@@ -214,6 +220,7 @@ class LohaModule(LycorisBaseModule):
                 None,
                 None,
                 gamma=scale,
+                constant_bias=self.use_constant_bias,
             )
         if shape is not None:
             weight = weight.reshape(shape)
@@ -276,6 +283,8 @@ class LohaModule(LycorisBaseModule):
         if self.tucker:
             destination["hada_t1"] = self.hada_t1
             destination["hada_t2"] = self.hada_t2
+        if self.use_constant_bias:
+            destination["use_constant_bias"] = torch.tensor(True)
         return destination
 
     @torch.no_grad()

--- a/lycoris/wrapper.py
+++ b/lycoris/wrapper.py
@@ -80,6 +80,7 @@ def create_lycoris(
     full_matrix = str_bool(kwargs.get("full_matrix", False))
     bypass_mode = str_bool(kwargs.get("bypass_mode", False))
     unbalanced_factorization = str_bool(kwargs.get("unbalanced_factorization", False))
+    use_constant_bias = str_bool(kwargs.get("use_constant_bias", False))
 
     if unbalanced_factorization:
         logger.info("Unbalanced factorization for LoKr is enabled")
@@ -127,6 +128,7 @@ def create_lycoris(
         full_matrix=full_matrix,
         bypass_mode=bypass_mode,
         unbalanced_factorization=unbalanced_factorization,
+        use_constant_bias=use_constant_bias,
         warn_on_unmatched=warn_on_unmatched,
     )
 


### PR DESCRIPTION
As identified by @kaibioinfo (all credit goes there) the LoHA formulation in the paper adds a constant bias term to w2.

When this is missing, the initial norm and delta of the module is **zero**, and learning can stall or take a very long time.

On the contrary, when the constant bias is present, it will start with a norm around 0.3 and the output changes immediately.

Whether it was desired or not, I was unsure. I've added a new parameter, `use_constant_bias` defaulting to `False` for compatibility, which can be enabled for users who wish to experiment or more closely follow the FedPara paper results (https://arxiv.org/abs/2108.06098)