### PR TITLE
Add Anima train_llm_adapter support

### DIFF
--- a/example_configs/preset_configs/example.toml
+++ b/example_configs/preset_configs/example.toml
@@ -13,7 +13,7 @@ unet_target_module = [
   "MMDoubleStreamBlock", #HunYuanVideo
   "MMSingleStreamBlock", #HunYuanVideo
   "JointTransformerBlock", # lumina-image-2
-  "FinalLayer", # lumina-image-2
+  "FinalLayer", # lumina-image-2, Anima
 ]
 unet_target_name = [
   "conv_in",

--- a/lycoris/config.py
+++ b/lycoris/config.py
@@ -18,7 +18,7 @@ FULL_UNET_MODULES = [
     "HunyuanVideoTransformerBlock",  # FramePack
     "HunyuanVideoSingleTransformerBlock",  # FramePack
     "JointTransformerBlock",  # lumina-image-2
-    "FinalLayer",  # lumina-image-2
+    "FinalLayer",  # lumina-image-2, Anima
     "QwenImageTransformerBlock",  # Qwen
     "ZImageTransformerBlock",
     "Block",  # Anima
@@ -74,7 +74,7 @@ BUILTIN_PRESET_CONFIGS = {
             "HunyuanVideoTransformerBlock",  # FramePack
             "HunyuanVideoSingleTransformerBlock",  # FramePack
             "JointTransformerBlock",  # lumina-image-2
-            "FinalLayer",  # lumina-image-2
+            "FinalLayer",  # lumina-image-2, Anima
             "QwenImageTransformerBlock",  # Qwen
             "ZImageTransformerBlock",
             "Block",  # Anima
@@ -103,7 +103,7 @@ BUILTIN_PRESET_CONFIGS = {
             "HunyuanVideoTransformerBlock",  # FramePack
             "HunyuanVideoSingleTransformerBlock",  # FramePack
             "JointTransformerBlock",  # lumina-image-2
-            "FinalLayer",  # lumina-image-2
+            "FinalLayer",  # lumina-image-2, Anima
             "QwenImageTransformerBlock",  # Qwen
             "ZImageTransformerBlock",
             "Block",  # Anima
@@ -154,7 +154,7 @@ BUILTIN_PRESET_CONFIGS = {
             "HunyuanVideoTransformerBlock",  # FramePack
             "HunyuanVideoSingleTransformerBlock",  # FramePack
             "JointTransformerBlock",  # lumina-image-2
-            "FinalLayer",  # lumina-image-2
+            "FinalLayer",  # lumina-image-2, Anima
             "QwenImageTransformerBlock",  # Qwen
             "ZImageTransformerBlock",
             "Block",  # Anima

--- a/lycoris/kohya.py
+++ b/lycoris/kohya.py
@@ -63,6 +63,7 @@ def create_network(
     rs_lora = str_bool(kwargs.get("rs_lora", False))
     unbalanced_factorization = str_bool(kwargs.get("unbalanced_factorization", False))
     train_t5xxl = str_bool(kwargs.get("train_t5xxl", False))
+    train_llm_adapter = str_bool(kwargs.get("train_llm_adapter", False))
     # lora_plus
     loraplus_lr_ratio = (
         float(kwargs.get("loraplus_lr_ratio", None))
@@ -133,6 +134,7 @@ def create_network(
         unbalanced_factorization=unbalanced_factorization,
         train_t5xxl=train_t5xxl,
         warn_on_unmatched=warn_on_unmatched,
+        train_llm_adapter=train_llm_adapter,
     )
     if (
         loraplus_lr_ratio is not None
@@ -257,7 +259,7 @@ class LycorisNetworkKohya(LycorisNetwork):
         "HunyuanVideoTransformerBlock",  # FramePack
         "HunyuanVideoSingleTransformerBlock",  # FramePack
         "JointTransformerBlock",  # lumina-image-2
-        "FinalLayer",  # lumina-image-2
+        "FinalLayer",  # lumina-image-2, Anima
         "QwenImageTransformerBlock",  # Qwen
         "ZImageTransformerBlock",
         "Block",  # Anima
@@ -333,6 +335,7 @@ class LycorisNetworkKohya(LycorisNetwork):
         train_norm=False,
         train_t5xxl=False,
         warn_on_unmatched=True,
+        train_llm_adapter=False,
         **kwargs,
     ) -> None:
         torch.nn.Module.__init__(self)
@@ -340,6 +343,7 @@ class LycorisNetworkKohya(LycorisNetwork):
         self.multiplier = multiplier
         self.lora_dim = lora_dim
         self.train_t5xxl = train_t5xxl
+        self.train_llm_adapter = train_llm_adapter
 
         # 初始化LoRA+相关属性
         self.loraplus_lr_ratio = None
@@ -552,10 +556,15 @@ class LycorisNetworkKohya(LycorisNetwork):
                 f"create LyCORIS for Text Encoder: {len(self.text_encoder_loras)} modules."
             )
 
+        target_modules = list(LycorisNetworkKohya.UNET_TARGET_REPLACE_MODULE)
+        if not self.train_llm_adapter:
+            if "LLMAdapterTransformerBlock" in target_modules:
+                target_modules.remove("LLMAdapterTransformerBlock")
+
         self.unet_loras, unet_matched_modules, unet_matched_names = create_modules(
             LycorisNetworkKohya.LORA_PREFIX_UNET,
             unet,
-            LycorisNetworkKohya.UNET_TARGET_REPLACE_MODULE,
+            target_modules,
             LycorisNetworkKohya.UNET_TARGET_REPLACE_NAME,
         )
         logger.info(f"create LyCORIS for U-Net: {len(self.unet_loras)} modules.")

--- a/lycoris/wrapper.py
+++ b/lycoris/wrapper.py
@@ -82,6 +82,7 @@ def create_lycoris(
     full_matrix = str_bool(kwargs.get("full_matrix", False))
     bypass_mode = str_bool(kwargs.get("bypass_mode", False))
     unbalanced_factorization = str_bool(kwargs.get("unbalanced_factorization", False))
+    train_llm_adapter = str_bool(kwargs.get("train_llm_adapter", False))
 
     if unbalanced_factorization:
         logger.info("Unbalanced factorization for LoKr is enabled")
@@ -130,6 +131,7 @@ def create_lycoris(
         bypass_mode=bypass_mode,
         unbalanced_factorization=unbalanced_factorization,
         warn_on_unmatched=warn_on_unmatched,
+        train_llm_adapter=train_llm_adapter,
     )
 
     return network
@@ -244,6 +246,7 @@ class LycorisNetwork(torch.nn.Module):
         train_norm=False,
         init_only=False,
         warn_on_unmatched=True,
+        train_llm_adapter=False,
         **kwargs,
     ) -> None:
         super().__init__()
@@ -264,6 +267,7 @@ class LycorisNetwork(torch.nn.Module):
             return
         self.multiplier = multiplier
         self.lora_dim = lora_dim
+        self.train_llm_adapter = train_llm_adapter
 
         if not self.ENABLE_CONV:
             conv_lora_dim = 0
@@ -485,6 +489,11 @@ class LycorisNetwork(torch.nn.Module):
                 ]
             )
         )
+
+        if not self.train_llm_adapter:
+            if "LLMAdapterTransformerBlock" in target_modules:
+                target_modules.remove("LLMAdapterTransformerBlock")
+
         self.loras, matched_modules, matched_names = create_modules(
             LycorisNetwork.LORA_PREFIX,
             module,


### PR DESCRIPTION
Original commit: https://github.com/67372a/LyCORIS/commit/8101d8c9cb52dba485352baf1133022e81aaf039

Add the `train_llm_adapter` network arg to allow disabling LLM adapter training when training Anima loras using LyCORIS with sd-scripts.