### PR TITLE
Fix FP8 bypass support and publish releases to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Publish Python package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+
+      - name: Verify release version
+        shell: bash
+        run: |
+          package_version="$(python setup.py --version)"
+          release_version="${GITHUB_REF_NAME#v}"
+          if [[ "${release_version}" != "${package_version}" ]]; then
+            echo "Release tag ${GITHUB_REF_NAME} does not match package version ${package_version}." >&2
+            exit 1
+          fi
+
+      - name: Build wheel and source distribution
+        run: python -m build
+
+      - name: Check distributions
+        run: python -m twine check dist/*
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish distributions to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/lycoris-lora
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/lycoris/kohya.py
+++ b/lycoris/kohya.py
@@ -20,7 +20,7 @@ from .modules.full import FullModule
 from .modules.diag_oft import DiagOFTModule
 from .modules.boft import ButterflyOFTModule
 from .modules import make_module, get_module
-from .modules.base import is_linear_like_module
+from .modules.base import is_supported_linear_module
 
 from .config import PRESET
 from .utils.preset import read_preset
@@ -404,7 +404,11 @@ class LycorisNetworkKohya(LycorisNetwork):
                     **kwargs,
                 )
             lora = None
-            if is_linear_like_module(module) and lora_dim > 0:
+            if is_supported_linear_module(
+                module,
+                algo_name,
+                weight_decompose=kwargs.get("weight_decompose", False),
+            ) and lora_dim > 0:
                 dim = dim or lora_dim
                 alpha = alpha or self.alpha
             elif isinstance(

--- a/lycoris/modules/base.py
+++ b/lycoris/modules/base.py
@@ -28,6 +28,19 @@ def is_linear_like_module(module: nn.Module) -> bool:
     return isinstance(module, nn.Linear) or is_weight_only_fp8_linear(module)
 
 
+_FP8_BYPASS_ALGOS = frozenset({"lora", "locon", "loha", "lokr", "glora"})
+
+
+def is_supported_linear_module(
+    module: nn.Module, algo_name: str, *, weight_decompose: bool = False
+) -> bool:
+    if is_weight_only_fp8_linear(module):
+        return algo_name in _FP8_BYPASS_ALGOS and (
+            algo_name == "lokr" or not weight_decompose
+        )
+    return isinstance(module, nn.Linear)
+
+
 def dequantize_weight_only_fp8(module: nn.Module) -> torch.Tensor:
     weight = module.weight.to(torch.float32)
     scale = module.weight_scale.to(device=weight.device, dtype=torch.float32)
@@ -406,6 +419,10 @@ class LycorisBaseModule(ModuleCustomSD):
     def onfly_merge(self, multiplier=1.0):
         if self.not_supported:
             return
+        if is_weight_only_fp8_linear(self.org_module[0]):
+            raise RuntimeError(
+                "Merging LyCORIS modules into weight-only FP8 Linear is not supported."
+            )
         self_device = next(self.parameters()).device
         self_dtype = next(self.parameters()).dtype
         self.to(self.org_weight)

--- a/lycoris/modules/glora.py
+++ b/lycoris/modules/glora.py
@@ -208,9 +208,12 @@ class GLoRAModule(LycorisBaseModule):
         return self.org_weight + diff_w, None
 
     def _bypass_forward(self, x, scale=1, diff=False):
-        scale = self.scale * scale
-        ax_mid = self.a2(x) * scale
-        bx_mid = self.b2(x) * scale
+        if self.module_type == "linear":
+            ax_mid = F.linear(x, self.a2.weight.to(x))
+            bx_mid = F.linear(x, self.b2.weight.to(x))
+        else:
+            ax_mid = self.a2(x)
+            bx_mid = self.b2(x)
 
         if self.rank_dropout and self.training:
             drop_a = (
@@ -230,12 +233,16 @@ class GLoRAModule(LycorisBaseModule):
                 drop_b = drop_b.view(*[1] * (dims - 1), -1)
             ax_mid = ax_mid * drop_a
             bx_mid = bx_mid * drop_b
-        return (
-            self.org_forward(
-                (0 if diff else x) + self.drop(self.a1(ax_mid)) * self.scale
-            )
-            + self.drop(self.b1(bx_mid)) * self.scale
-        )
+        if self.module_type == "linear":
+            ax = F.linear(ax_mid, self.a1.weight.to(ax_mid))
+            bx = F.linear(bx_mid, self.b1.weight.to(bx_mid))
+        else:
+            ax = self.a1(ax_mid)
+            bx = self.b1(bx_mid)
+        ax_scale = self.scalar.to(ax) * self.scale * scale
+        bx_scale = self.scalar.to(bx) * self.scale * scale
+        base_input = (0 if diff else x) + self.drop(ax) * ax_scale
+        return self.org_forward(base_input) + self.drop(bx) * bx_scale
 
     def bypass_forward_diff(self, x, scale=1):
         return self._bypass_forward(x, scale=scale, diff=True)

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -93,7 +93,7 @@ class LoConModule(LycorisBaseModule):
                     in_dim, lora_dim, k_size, stride, padding, bias=False
                 )
             self.lora_up = self.module(lora_dim, out_dim, 1, bias=False)
-        elif isinstance(org_module, nn.Linear):
+        elif self.module_type == "linear":
             self.isconv = False
             self.down_op = F.linear
             self.up_op = F.linear
@@ -284,7 +284,9 @@ class LoConModule(LycorisBaseModule):
         return scaled, orig_norm * ratio
 
     def bypass_forward_diff(self, x, scale=1):
-        if self.tucker:
+        if self.module_type == "linear":
+            mid = F.linear(x, self.lora_down.weight.to(x))
+        elif self.tucker:
             mid = self.lora_mid(self.lora_down(x))
         else:
             mid = self.lora_down(x)
@@ -301,7 +303,12 @@ class LoConModule(LycorisBaseModule):
                 drop = drop.view(*[1] * (dims - 1), -1)
             mid = mid * drop
 
-        return self.dropout(self.lora_up(mid) * self.scalar * self.scale * scale)
+        if self.module_type == "linear":
+            output = F.linear(mid, self.lora_up.weight.to(mid))
+        else:
+            output = self.lora_up(mid)
+        scalar = self.scalar.to(device=output.device, dtype=output.dtype)
+        return self.dropout(output * scalar * self.scale * scale)
 
     def bypass_forward(self, x, scale=1):
         return self.org_forward(x) + self.bypass_forward_diff(x, scale=scale)

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -292,7 +292,8 @@ class LohaModule(LycorisBaseModule):
         return scaled, orig_norm * ratio
 
     def bypass_forward_diff(self, x, scale=1):
-        diff_weight = self.get_weight(self.shape) * self.scalar * scale
+        scalar = self.scalar.to(device=x.device, dtype=x.dtype)
+        diff_weight = self.get_weight(self.shape).to(x) * scalar * scale
         return self.drop(self.op(x, diff_weight, **self.kw_dict))
 
     def bypass_forward(self, x, scale=1):

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -5,7 +5,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from .base import LycorisBaseModule
+from .base import LycorisBaseModule, is_weight_only_fp8_linear
 from ..functional import factorization, rebuild_tucker
 from ..functional.lokr import make_kron
 from ..logging import logger
@@ -545,19 +545,17 @@ class LokrModule(LycorisBaseModule):
             hc = hc.transpose(-1, -2)
             h = hc.reshape(*hc.shape[:-2], -1)
 
-        return self.drop(h * scale * self.scalar.to(device=device, dtype=dtype))
+        return self.drop(
+            h
+            * self.scale
+            * scale
+            * self.scalar.to(device=device, dtype=dtype)
+        )
 
     def bypass_forward(self, x, scale=1):
         return self.org_forward(x) + self.bypass_forward_diff(x, scale=scale)
 
-    def forward(self, x: torch.Tensor, *args, **kwargs):
-        if self.module_dropout and self.training:
-            if torch.rand(1) < self.module_dropout:
-                return self.org_forward(x, *args, **kwargs)
-
-        if self.bypass_mode:
-            return self.bypass_forward(x, self.multiplier)
-
+    def _rebuild_forward(self, x, *args, **kwargs):
         base = self.org_forward(x, *args, **kwargs)
         base_weight = self._current_weight().to(x.device)
         diff_weight = self.get_weight(self.shape).to(base_weight.dtype) * self.scalar
@@ -574,6 +572,18 @@ class LokrModule(LycorisBaseModule):
         delta_weight = (new_weight - base_weight).to(device=x.device, dtype=x.dtype)
         delta = self.op(x, delta_weight, None, **self.kw_dict)
         return base + delta
+
+    def forward(self, x: torch.Tensor, *args, **kwargs):
+        if self.module_dropout and self.training:
+            if torch.rand(1) < self.module_dropout:
+                return self.org_forward(x, *args, **kwargs)
+
+        fp8_weight_decompose = self.wd and is_weight_only_fp8_linear(
+            self.org_module[0]
+        )
+        if self.bypass_mode and not fp8_weight_decompose:
+            return self.bypass_forward(x, self.multiplier)
+        return self._rebuild_forward(x, *args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/lycoris/wrapper.py
+++ b/lycoris/wrapper.py
@@ -20,7 +20,7 @@ from .modules.diag_oft import DiagOFTModule
 from .modules.boft import ButterflyOFTModule
 from .modules.tlora import TLoraModule
 from .modules import get_module, make_module
-from .modules.base import is_linear_like_module
+from .modules.base import is_supported_linear_module, is_weight_only_fp8_linear
 
 from .config import PRESET
 from .config_sdk import VALID_PRESET_KEYS
@@ -318,7 +318,11 @@ class LycorisNetwork(torch.nn.Module):
                     **kwargs,
                 )
             lora = None
-            if is_linear_like_module(module) and lora_dim > 0:
+            if is_supported_linear_module(
+                module,
+                algo_name,
+                weight_decompose=kwargs.get("weight_decompose", False),
+            ) and lora_dim > 0:
                 dim = dim or lora_dim
                 alpha = alpha or self.alpha
             elif isinstance(
@@ -591,17 +595,27 @@ class LycorisNetwork(torch.nn.Module):
             logger.info(f"weights are loaded: {info}")
 
     def is_mergeable(self):
-        return True
+        return not any(
+            is_weight_only_fp8_linear(lora.org_module[0]) for lora in self.loras
+        )
+
+    def _ensure_mergeable(self):
+        if not self.is_mergeable():
+            raise RuntimeError(
+                "Merging LyCORIS modules into weight-only FP8 Linear is not supported."
+            )
 
     def restore(self):
         for lora in self.loras:
             lora.restore()
 
     def merge_to(self, weight=1.0, *, precise: bool = False):
+        self._ensure_mergeable()
         for lora in self.loras:
             lora.merge_to(weight, precise=precise)
 
     def onfly_merge(self, weight=1.0):
+        self._ensure_mergeable()
         for lora in self.loras:
             lora.onfly_merge(weight)
 

--- a/test/module.py
+++ b/test/module.py
@@ -66,6 +66,109 @@ patch_forward_param_list = list(
 
 
 class LycorisModuleTests(unittest.TestCase):
+    @staticmethod
+    def make_fp8_model(*, include_linear=False, include_adaln=False, dim=4):
+        class Fp8Linear(nn.Linear):
+            def __init__(self, in_features, out_features):
+                nn.Module.__init__(self)
+                self.in_features = in_features
+                self.out_features = out_features
+                self.compute_dtype = torch.bfloat16
+                self.register_buffer(
+                    "weight",
+                    torch.ones(out_features, in_features).to(torch.float8_e4m3fn),
+                )
+                self.register_buffer(
+                    "weight_scale", torch.linspace(0.25, 1.0, out_features)
+                )
+                self.bias = None
+
+            def forward(self, x):
+                weight = self.weight.to(x.dtype) * self.weight_scale.to(
+                    x.dtype
+                ).unsqueeze(1)
+                return F.linear(x, weight, self.bias)
+
+        class Ideogram4TransformerBlock(nn.Module):
+            def __init__(self):
+                super().__init__()
+                if include_linear:
+                    self.linear = nn.Linear(dim, dim)
+                if include_adaln:
+                    self.adaln_modulation = nn.Linear(dim, dim * 2, bias=True).to(
+                        torch.bfloat16
+                    )
+                self.fp8_linear = Fp8Linear(dim, dim)
+
+            def forward(self, x):
+                fp8_output = self.fp8_linear(x)
+                if include_adaln:
+                    return self.adaln_modulation(x), fp8_output
+                return fp8_output
+
+        return nn.Sequential(Ideogram4TransformerBlock())
+
+    def fp8_and_rebuild_outputs(self, algo, *, weight_decompose=False):
+        from lycoris.kohya import create_network
+        from lycoris.modules.base import dequantize_weight_only_fp8
+
+        dim = 24
+        model = self.make_fp8_model(dim=dim)
+        network = create_network(
+            0.7,
+            2,
+            1.0,
+            None,
+            None,
+            model,
+            algo=algo,
+            preset="full-lin",
+            conv_dim=0,
+            use_scalar=True,
+            dora_wd=weight_decompose,
+            warn_on_unmatched=False,
+        )
+        self.assertEqual(len(network.unet_loras), 1)
+        fp8_lora = network.unet_loras[0]
+
+        generator = torch.Generator().manual_seed(1234)
+        with torch.no_grad():
+            for name, param in fp8_lora.named_parameters():
+                if name == "dora_scale":
+                    continue
+                param.copy_(
+                    torch.rand(
+                        param.shape,
+                        generator=generator,
+                        device=param.device,
+                        dtype=param.dtype,
+                    )
+                    * 0.4
+                    - 0.2
+                )
+
+        fp8_base = fp8_lora.org_module[0]
+        reference_base = nn.Linear(dim, dim, bias=False)
+        with torch.no_grad():
+            reference_base.weight.copy_(dequantize_weight_only_fp8(fp8_base))
+        reference_lora = type(fp8_lora)(
+            "reference",
+            reference_base,
+            multiplier=0.7,
+            lora_dim=2,
+            alpha=1.0,
+            use_scalar=True,
+            weight_decompose=weight_decompose,
+            bypass_mode=False,
+        )
+        reference_lora.load_state_dict(fp8_lora.state_dict(), strict=False)
+
+        network.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+        network.eval()
+        reference_lora.eval()
+        x = torch.linspace(-1, 1, 2 * 3 * dim).reshape(2, 3, dim)
+        return model(x), reference_lora(x)
+
     @parameterized.expand(patch_forward_param_list)
     def test_lycoris_modules(self, module, base, device_dtype, wd, tucker, scalar):
         base, test_input = base(16)
@@ -187,33 +290,7 @@ class LycorisModuleTests(unittest.TestCase):
     def test_kohya_lokr_discovers_fp8_linear_and_handles_bf16_no_autocast(self):
         from lycoris.kohya import create_network
 
-        class Fp8Linear(nn.Module):
-            def __init__(self, in_features, out_features, compute_dtype):
-                super().__init__()
-                self.in_features = in_features
-                self.out_features = out_features
-                self.compute_dtype = compute_dtype
-                self.register_buffer("weight", torch.ones(out_features, in_features))
-                self.register_buffer("weight_scale", torch.full((out_features,), 0.01))
-                self.bias = None
-
-            def forward(self, x):
-                scale = self.weight_scale.to(device=x.device, dtype=x.dtype)
-                if scale.ndim == 1:
-                    scale = scale.unsqueeze(1)
-                weight = self.weight.to(device=x.device, dtype=x.dtype) * scale
-                return F.linear(x, weight, self.bias)
-
-        class Ideogram4TransformerBlock(nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.adaln_modulation = nn.Linear(4, 8, bias=True).to(torch.bfloat16)
-                self.qkv = Fp8Linear(4, 4, compute_dtype=torch.bfloat16)
-
-            def forward(self, x):
-                return self.adaln_modulation(x), self.qkv(x)
-
-        model = nn.Sequential(Ideogram4TransformerBlock())
+        model = self.make_fp8_model(include_adaln=True)
         network = create_network(
             1.0,
             2,
@@ -236,8 +313,34 @@ class LycorisModuleTests(unittest.TestCase):
         self.assertTrue(fp8_loras[0].bypass_mode)
         self.assertTrue(fp8_loras[0].is_quant)
         self.assertTrue(fp8_loras[0].wd)
+        regular_lora = next(
+            lora
+            for lora in network.unet_loras
+            if lora.org_module[0].__class__.__name__ != "Fp8Linear"
+        )
+        with torch.no_grad():
+            for name, param in regular_lora.named_parameters():
+                if name != "dora_scale":
+                    param.fill_(0.1)
+        regular_weight = regular_lora.org_weight.detach().clone()
         with self.assertRaisesRegex(RuntimeError, "weight-only FP8"):
             fp8_loras[0].merge_to()
+        with self.assertRaisesRegex(RuntimeError, "weight-only FP8"):
+            fp8_loras[0].onfly_merge()
+        with self.assertRaisesRegex(RuntimeError, "weight-only FP8"):
+            network.merge_to(
+                None,
+                model,
+                {"lora_unet_dummy": torch.tensor(0)},
+                None,
+                None,
+            )
+        torch.testing.assert_close(regular_lora.org_weight, regular_weight)
+        with self.assertRaisesRegex(RuntimeError, "weight-only FP8"):
+            network.onfly_merge()
+        self.assertFalse(
+            any(hasattr(lora, "cached_org_weight") for lora in network.loras)
+        )
 
         network.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
         x = torch.randn(2, 3, 4, dtype=torch.bfloat16)
@@ -246,3 +349,122 @@ class LycorisModuleTests(unittest.TestCase):
         self.assertEqual(y_fp8.dtype, torch.bfloat16)
         self.assertTrue(torch.isfinite(y_adaln.float()).all())
         self.assertTrue(torch.isfinite(y_fp8.float()).all())
+
+    def test_kohya_supported_bypass_algorithms_handle_fp8_linear(self):
+        from lycoris.kohya import create_network
+
+        devices = [torch.device("cpu")]
+        if torch.cuda.is_available():
+            devices.append(torch.device("cuda"))
+
+        for algo, device in product(
+            ("lora", "locon", "loha", "glora"), devices
+        ):
+            with self.subTest(algo=algo, device=device):
+                model = self.make_fp8_model().to(device)
+                network = create_network(
+                    1.0,
+                    2,
+                    1.0,
+                    None,
+                    None,
+                    model,
+                    algo=algo,
+                    preset="full-lin",
+                    conv_dim=0,
+                    warn_on_unmatched=False,
+                )
+                self.assertEqual(len(network.unet_loras), 1)
+                self.assertTrue(
+                    network.unet_loras[0].org_module[0].__class__.__name__
+                    == "Fp8Linear"
+                )
+
+                network.apply_to(None, model, apply_text_encoder=False, apply_unet=True)
+                network.to(device)
+                x = torch.randn(
+                    2,
+                    3,
+                    4,
+                    device=device,
+                    dtype=torch.bfloat16,
+                    requires_grad=True,
+                )
+                output = model(x)
+                output.float().sum().backward()
+
+                self.assertEqual(output.dtype, torch.bfloat16)
+                self.assertTrue(torch.isfinite(output.float()).all())
+                self.assertTrue(
+                    any(
+                        param.grad is not None
+                        and torch.isfinite(param.grad.float()).all()
+                        for param in network.parameters()
+                        if param.requires_grad
+                    )
+                )
+
+    def test_kohya_fp8_bypass_matches_rebuilt_weight(self):
+        for algo in ("lora", "locon", "loha", "lokr", "glora"):
+            with self.subTest(algo=algo):
+                actual, expected = self.fp8_and_rebuild_outputs(algo)
+                torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    def test_kohya_lokr_fp8_weight_decompose_matches_rebuilt_weight(self):
+        actual, expected = self.fp8_and_rebuild_outputs(
+            "lokr", weight_decompose=True
+        )
+        torch.testing.assert_close(actual, expected, atol=1e-5, rtol=1e-5)
+
+    def test_kohya_unsupported_bypass_algorithms_skip_fp8_linear(self):
+        from lycoris.kohya import create_network
+
+        for algo in ("dylora", "full", "diag-oft", "boft", "tlora"):
+            with self.subTest(algo=algo):
+                model = self.make_fp8_model(include_linear=True)
+                network = create_network(
+                    1.0,
+                    2,
+                    1.0,
+                    None,
+                    None,
+                    model,
+                    algo=algo,
+                    preset="full-lin",
+                    conv_dim=0,
+                    block_size=2,
+                    warn_on_unmatched=False,
+                )
+                fp8_loras = [
+                    lora
+                    for lora in network.unet_loras
+                    if lora.org_module[0].__class__.__name__ == "Fp8Linear"
+                ]
+                self.assertEqual(fp8_loras, [])
+                self.assertEqual(len(network.unet_loras), 1)
+
+    def test_kohya_fp8_non_lokr_weight_decompose_is_skipped(self):
+        from lycoris.kohya import create_network
+
+        for algo in ("lora", "locon", "loha", "glora"):
+            with self.subTest(algo=algo):
+                model = self.make_fp8_model(include_linear=True)
+                network = create_network(
+                    1.0,
+                    2,
+                    1.0,
+                    None,
+                    None,
+                    model,
+                    algo=algo,
+                    preset="full-lin",
+                    conv_dim=0,
+                    dora_wd=True,
+                    warn_on_unmatched=False,
+                )
+                self.assertFalse(
+                    any(
+                        lora.org_module[0].__class__.__name__ == "Fp8Linear"
+                        for lora in network.unet_loras
+                    )
+                )


### PR DESCRIPTION
Follow-up to #283.

## Summary

- recognize weight-only `Fp8Linear` by capability before the generic `nn.Linear` path
- enable FP8 bypass only for verified algorithms: LoRA/LoCon, LoHa, LoKr, and GLoRA
- skip unsupported algorithms and non-LoKr weight decomposition instead of constructing broken adapters
- make LoKr and GLoRA bypass numerically match rebuilt-weight execution, including LoKr FP8 DoRA
- reject regular and on-the-fly FP8 merges before any module is mutated
- build and publish wheel/sdist packages from published GitHub Releases through PyPI trusted publishing

## Verification

- 6 focused FP8 tests pass, including real `float8_e4m3fn`, BF16 without autocast, CPU/CUDA forward-backward, capability filtering, numerical equivalence, DoRA, and atomic merge guards
- `python -m compileall -q lycoris test/module.py`
- `actionlint 1.7.12 .github/workflows/release.yml`
- `python -m build`
- `python -m twine check <wheel> <sdist>`
- `git diff --check`

## Deployment note

PyPI trusted publishing must allow `KohakuBlueleaf/LyCORIS`, workflow `release.yml`, environment `pypi`. Release tags must match `setup.py` versions, with an optional leading `v`.