### PR TITLE
fix: use in_channels/groups for Conv*d LoRA weight shapes (#260)

### DIFF
--- a/lycoris/modules/base.py
+++ b/lycoris/modules/base.py
@@ -157,9 +157,10 @@ class LycorisBaseModule(ModuleCustomSD):
             self.kw_dict = {}
         elif isinstance(org_module, nn.Conv1d):
             self.module_type = "conv1d"
+            # Weight layout matches torch.nn.Conv*d: (out, in/groups, *kernel)
             self.shape = (
                 org_module.out_channels,
-                org_module.in_channels,
+                org_module.in_channels // org_module.groups,
                 *org_module.kernel_size,
             )
             self.op = F.conv1d
@@ -174,7 +175,7 @@ class LycorisBaseModule(ModuleCustomSD):
             self.module_type = "conv2d"
             self.shape = (
                 org_module.out_channels,
-                org_module.in_channels,
+                org_module.in_channels // org_module.groups,
                 *org_module.kernel_size,
             )
             self.op = F.conv2d
@@ -189,7 +190,7 @@ class LycorisBaseModule(ModuleCustomSD):
             self.module_type = "conv3d"
             self.shape = (
                 org_module.out_channels,
-                org_module.in_channels,
+                org_module.in_channels // org_module.groups,
                 *org_module.kernel_size,
             )
             self.op = F.conv3d

--- a/lycoris/modules/locon.py
+++ b/lycoris/modules/locon.py
@@ -73,8 +73,9 @@ class LoConModule(LycorisBaseModule):
 
         if self.module_type.startswith("conv"):
             self.isconv = True
-            # For general LoCon
-            in_dim = org_module.in_channels
+            # For general LoCon. in_dim follows torch Conv weight layout (in/groups)
+            # so rebuild_weight matches F.conv*d when groups != 1 (#260).
+            in_dim = org_module.in_channels // org_module.groups
             k_size = org_module.kernel_size
             stride = org_module.stride
             padding = org_module.padding
@@ -82,6 +83,11 @@ class LoConModule(LycorisBaseModule):
             use_tucker = use_tucker and any(i != 1 for i in k_size)
             self.down_op = self.op
             self.up_op = self.op
+            if org_module.groups != 1 and self.bypass_mode:
+                # Adapter Conv modules are groups=1 and take in/groups channels;
+                # bypass forward on the full activation is not valid for grouped
+                # originals, so force the weight-rebuild path.
+                self.bypass_mode = False
             if use_tucker and any(i != 1 for i in k_size):
                 self.lora_down = self.module(in_dim, lora_dim, 1, bias=False)
                 self.lora_mid = self.module(

--- a/lycoris/modules/loha.py
+++ b/lycoris/modules/loha.py
@@ -65,7 +65,7 @@ class LohaModule(LycorisBaseModule):
 
         w_shape = self.shape
         if self.module_type.startswith("conv"):
-            in_dim = org_module.in_channels
+            in_dim = org_module.in_channels // org_module.groups
             k_size = org_module.kernel_size
             out_dim = org_module.out_channels
             self.shape = (out_dim, in_dim, *k_size)

--- a/lycoris/modules/lokr.py
+++ b/lycoris/modules/lokr.py
@@ -87,7 +87,7 @@ class LokrModule(LycorisBaseModule):
         self.rs_lora = rs_lora
 
         if self.module_type.startswith("conv"):
-            in_dim = org_module.in_channels
+            in_dim = org_module.in_channels // org_module.groups
             k_size = org_module.kernel_size
             out_dim = org_module.out_channels
             self.shape = (out_dim, in_dim, *k_size)

--- a/test/grouped_conv_locon.py
+++ b/test/grouped_conv_locon.py
@@ -1,0 +1,58 @@
+"""Regression for #260: LoCon on grouped Conv2d must use in/groups weight layout."""
+
+import torch
+import torch.nn as nn
+
+from lycoris.modules.locon import LoConModule
+
+
+def test_grouped_conv2d_locon_forward_and_weight_shape():
+    groups = 8
+    channels = 32
+    assert channels % groups == 0
+
+    conv = nn.Conv2d(channels, channels, kernel_size=3, padding=1, groups=groups, bias=False)
+    module = LoConModule(
+        "test.grouped",
+        conv,
+        multiplier=1.0,
+        lora_dim=4,
+        alpha=4,
+        bypass_mode=False,
+    )
+
+    assert module.shape == (channels, channels // groups, 3, 3)
+    assert module.lora_down.weight.shape == (4, channels // groups, 3, 3)
+    assert module.kw_dict["groups"] == groups
+
+    x = torch.randn(2, channels, 16, 16)
+    y = module(x)
+    assert y.shape == x.shape
+
+    diff, _ = module.get_diff_weight(device=x.device)
+    assert diff.shape == conv.weight.shape
+
+
+def test_depthwise_conv2d_locon_forward():
+    channels = 16
+    conv = nn.Conv2d(channels, channels, kernel_size=3, padding=1, groups=channels, bias=True)
+    module = LoConModule(
+        "test.depthwise",
+        conv,
+        multiplier=1.0,
+        lora_dim=2,
+        alpha=2,
+        bypass_mode=True,  # should be forced off for groups != 1
+    )
+    assert module.bypass_mode is False
+    assert module.shape == (channels, 1, 3, 3)
+
+    x = torch.randn(1, channels, 8, 8)
+    y = module(x)
+    assert y.shape == x.shape
+
+
+if __name__ == "__main__":
+    test_grouped_conv2d_locon_forward_and_weight_shape()
+    test_depthwise_conv2d_locon_forward()
+    print("ok")


### PR DESCRIPTION
## Summary

Fixes #260. Grouped `Conv1d`/`Conv2d`/`Conv3d` weights follow the PyTorch layout `(out_channels, in_channels/groups, *kernel_size)`. LyCORIS was rebuilding LoRA deltas with full `in_channels`, so `F.conv*d(..., groups=G)` expected `in*G` channels and failed on models like Ultralytics RT-DETR depthwise/grouped layers.

This updates:
- `base.py` shape + `kw_dict` consumers
- LoCon adapter `in_dim` (and forces rebuild mode when `groups != 1`, since groups=1 adapters cannot bypass-forward on the full activation)
- LoHa / LoKr shape overrides that previously rewrote `self.shape` with the ungrouped width

## Evidence

```text
$ set PYTHONPATH=.
$ python test/grouped_conv_locon.py
ok
```

Covers grouped and depthwise Conv2d forward + weight shape parity with `org_module.weight`.

## AI assistance

Assisted by Cursor/Grok. Human author: Stan Shih (@stantheman0128). I reviewed the diff and ran the regression above.